### PR TITLE
Consistency in dispatch() arguments

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -42,8 +42,9 @@ class LoginRequiredMixin(object):
     """
 
     @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        return super(LoginRequiredMixin, self).dispatch(request,
+            *args, **kwargs)
 
 
 class PermissionRequiredMixin(object):


### PR DESCRIPTION
I noticed that the LoginRequiredMixin was not consistent with the other mixins about passing the request arguments separately from *args.

I fixed that.
