### PR TITLE
Fixed bug in SelectRelatedMixin.

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -312,10 +312,7 @@ class SelectRelatedMixin(object):
         # Get the current queryset of the view
         queryset = super(SelectRelatedMixin, self).get_queryset()
 
-        # Return the queryset with a comma-joined argument to `select_related`.
-        return queryset.select_related(
-            ", ".join(self.select_related)
-        )
+        return queryset.select_related(*self.select_related)
 
 
 class StaffuserRequiredMixin(object):


### PR DESCRIPTION
The current implementation of `SelectRelatedMixin` is broken when the view's `select_related` attribute contains more than one element.
