### PR TITLE
JSONResponseMixin throws an exception in Django 1.5

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from django.utils import simplejson as json
 
+
 class CreateAndRedirectToEditView(CreateView):
     """
     Subclass of CreateView which redirects to the edit view.


### PR DESCRIPTION
All JSONResponseMixin views in my Django 1.5 app throw an exception when using the (now deprecated) `django.utils.simplejson` library:

```
Internal Server Error: /account/billing/update-card/
Traceback (most recent call last):
  File "/home/derek/dev/django-montage/django/core/handlers/base.py", line 116, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/derek/dev/django-montage/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/derek/.virtualenvs/montage/local/lib/python2.7/site-packages/braces/views.py", line 381, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/derek/dev/django-montage/montage/apps/bank/views/billing.py", line 27, in post_ajax
    return self.render_json_response({})
  File "/home/derek/.virtualenvs/montage/local/lib/python2.7/site-packages/braces/views.py", line 354, in render_json_response
    json_context = json.dumps(context_dict, cls=DjangoJSONEncoder, ensure_ascii=False)
  File "/home/derek/.virtualenvs/montage/local/lib/python2.7/site-packages/simplejson/__init__.py", line 334, in dumps
    **kw).encode(obj)
TypeError: __init__() got an unexpected keyword argument 'namedtuple_as_object'
```

This patch updates `braces.views` to check for the built-in json library first, with a fallback for older Python/Django versions.
