### PR TITLE
Add six to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mock
 pytest-django
 pytest-cov
+six


### PR DESCRIPTION
Recently six was added as an import in views, but wasn't added to
requirements.txt. This adds it.
