### PR TITLE
PermissionRequiredMixin doesn't allow custom permissions/object permissions

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -140,10 +140,11 @@ class PermissionRequiredMixin(AccessMixin):
         perms = self.get_permission_required(request)
         return request.user.has_perm(perms)
 
-    def no_permissions_fail(self, request=None):
+    def get_no_permissions_response(self, request):
         """
         Called when the user has no permissions. This should only return a
-        valid http response or False/None if using for just the side effects.
+        valid http response. You can override it and perform additional actions
+        prior to redirecting.
 
         By default we redirect to login.
         """
@@ -159,11 +160,7 @@ class PermissionRequiredMixin(AccessMixin):
             if self.raise_exception:
                 raise PermissionDenied # Return a 403
             else:  # use our fallback failure method
-                resp = self.no_permissions_fail(request)
-                # Only return if we have a return value (a response).
-                # It may be overriden to just cause a side effect
-                if resp:
-                    return resp
+                return self.get_no_permissions_response(request)
 
         return super(PermissionRequiredMixin, self).dispatch(
             request, *args, **kwargs)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,6 +4,9 @@ from .compat import patterns, url
 
 urlpatterns = patterns(
     '',
+    # Simple view that returns `OK`
+    url(r'^ok/$', views.OkView.as_view()),
+
     # LoginRequiredMixin tests
     url(r'^login_required/$', views.LoginRequiredView.as_view()),
 
@@ -39,6 +42,8 @@ urlpatterns = patterns(
 
     # PermissionRequiredMixin tests
     url(r'^permission_required/$', views.PermissionRequiredView.as_view()),
+    url(r'^custom_permissions_required/$',
+        views.PermissionRequiredOrStaffView.as_view()),
 
     # MultiplePermissionsRequiredMixin tests
     url(r'^multiple_permissions_required/$',

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,6 +2,7 @@ import codecs
 
 from django.contrib.auth.models import User
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django.views.generic import (View, UpdateView, FormView, TemplateView,
                                   ListView, DetailView, CreateView)
 
@@ -199,6 +200,21 @@ class MultiplePermissionsRequiredView(views.MultiplePermissionsRequiredMixin,
     }
 
 
+class PermissionRequiredOrStaffView(views.PermissionRequiredMixin, OkView):
+
+    raise_exception = False
+
+    def get_permission_required(self, request=None):
+        return 'auth.add_user'
+
+    def check_permissions(self, request):
+        perms = self.get_permission_required()
+        # Custom check thats different from the default
+        return request.user.has_perm(perms) or request.user.is_staff
+
+    def get_no_permissions_response(self, request):
+        return redirect('/ok/')
+
 class SuperuserRequiredView(views.SuperuserRequiredMixin, OkView):
     pass
 
@@ -254,3 +270,4 @@ class FormMessagesView(views.FormMessagesMixin, CreateView):
 
 class GroupRequiredView(views.GroupRequiredMixin, OkView):
     group_required = 'test_group'
+


### PR DESCRIPTION
The PermissionRequiredMixin does not allow for checking custom object permissions provided by libraries like django object permissions or django-guardian.

I was thinking of updating it to be similar to https://github.com/lukaszb/django-guardian/blob/master/guardian/mixins.py#L52

Except stripping out the parts where it does object specific actions or guardian specific things, and allow overriding to implement said functionality.
