### PR TITLE
CanonicalSlugDetailMixin now inherits from `object`.

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -12,7 +12,6 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
-from django.views.generic.detail import SingleObjectMixin
 from django.views.decorators.csrf import csrf_exempt
 
 ## Django 1.5+ compat
@@ -627,7 +626,7 @@ class OrderableListMixin(object):
         return self.get_ordered_queryset(unordered_queryset)
 
 
-class CanonicalSlugDetailMixin(SingleObjectMixin):
+class CanonicalSlugDetailMixin(object):
     """
     A mixin that enforces a canonical slug in the url.
 


### PR DESCRIPTION
I don't believe `CanonicalSlugMixin` should inherit from `SingleObjectMixin`.  Doing so will mask any custom `.get_object()` method that the user may be providing in their base view.

The documentation also states that this mixin works with `DetailView`, making the inheritance of `SingleObjectMixin` unnecessary.
