### PR TITLE
Making the CanonicalSlugDetailMixin namespace aware.

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -636,10 +636,13 @@ class CanonicalSlugDetailMixin(SingleObjectMixin):
     redirect to the url containing the canonical slug.
     """
     def dispatch(self, request, *args, **kwargs):
-        # Get the current object, url slug, and urlpattern name.
+        # Get the current object, url slug, and urlpattern name (namespace aware).
         obj = self.get_object()
         slug = self.kwargs.get(self.slug_url_kwarg, None)
-        current_urlpattern = resolve(request.path_info).url_name
+        match = resolve(request.path_info)
+        url_parts = match.namespaces
+        url_parts.append(match.url_name)
+        current_urlpattern = ':'.join(url_parts)
 
         # Figure out what the slug is supposed to be.
         canonical_slug = self.get_canonical_slug()

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -268,6 +268,31 @@ class TestCanonicalSlugDetailView(test.TestCase):
         self.assertEqual(resp.status_code, 301)
 
 
+class TestNamespaceAwareCanonicalSlugDetailView(test.TestCase):
+    def setUp(self):
+        a1 = Article.objects.create(title='Alpha', body='Zet', slug='alpha')
+        a2 = Article.objects.create(title='Zet', body='Alpha', slug='zet')
+
+    def test_canonical_slug(self):
+        """
+        Test that no redirect occurs when slug is canonical.
+        """
+        resp = self.client.get('/article-canonical-namespaced/article/1-alpha/')
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get('/article-canonical-namespaced/article/2-zet/')
+        self.assertEqual(resp.status_code, 200)
+
+    def test_non_canonical_slug(self):
+        """
+        Test that a redirect occurs when the slug is non-canonical and that the
+        redirect is namespace aware.
+        """
+        resp = self.client.get('/article-canonical-namespaced/article/1-bad-slug/')
+        self.assertEqual(resp.status_code, 301)
+        resp = self.client.get('/article-canonical-namespaced/article/2-bad-slug/')
+        self.assertEqual(resp.status_code, 301)
+
+
 class TestOverriddenCanonicalSlugDetailView(test.TestCase):
     def setUp(self):
         a1 = Article.objects.create(title='Alpha', body='Zet', slug='alpha')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
 from . import views
-from .compat import patterns, url
+from .compat import patterns, include, url
 
 
 urlpatterns = patterns(
@@ -25,6 +25,8 @@ urlpatterns = patterns(
     # CanonicalSlugDetailMixin tests
     url(r'^article-canonical/(?P<pk>\d+)-(?P<slug>[-\w]+)/$',
         views.CanonicalSlugDetailView.as_view()),
+    url(r'^article-canonical-namespaced/',
+        include('tests.urls_namespaced', namespace='some_namespace')),
     url(r'^article-canonical-override/(?P<pk>\d+)-(?P<slug>[-\w]+)/$',
         views.OverriddenCanonicalSlugDetailView.as_view()),
     url(r'^article-canonical-model/(?P<pk>\d+)-(?P<slug>[-\w]+)/$',

--- a/tests/urls_namespaced.py
+++ b/tests/urls_namespaced.py
@@ -1,0 +1,11 @@
+from . import views
+from .compat import patterns, url
+
+
+urlpatterns = patterns(
+    '',
+    # CanonicalSlugDetailMixin namespace tests
+    url(r'^article/(?P<pk>\d+)-(?P<slug>[\w-]+)/$',
+        views.CanonicalSlugDetailView.as_view(),
+        name="namespaced_article"),
+)


### PR DESCRIPTION
The current version of CanonicalSLugDetailMixin is not namespace aware. I have fixed that and written some tests to validate it. There are probably better ways to do this, but this was enough to fix the problems I was having.
