### PR TITLE
Defined self.request in dispatch before calling a view method that depen...

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -274,6 +274,7 @@ class GroupRequiredMixin(AccessMixin):
         return True
 
     def dispatch(self, request, *args, **kwargs):
+        self.request = request
         in_group = self.check_membership(self.get_group_required())
 
         if not in_group:


### PR DESCRIPTION
`GroupRequiredMixin.check_membership()` accesses `self.request.user.groups.values_list()`. This causes `GroupRequiredMixin` to throw an `AttributeError` when used in a view as `self.request` is not yet defined until the `super` call at the end of `dispatch`.

This leads me to wonder if I'm the first person really using `GroupRequiredMixin`... :+1: 
