### PR TITLE
Make AccessMixin.login_url changeable at runtime

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -26,7 +26,7 @@ class AccessMixin(object):
     'Abstract' mixin that gives access mixins the same customizable
     functionality.
     """
-    login_url = settings.LOGIN_URL  # LOGIN_URL from project settings
+    login_url = None
     raise_exception = False  # Default whether to raise an exception to none
     redirect_field_name = REDIRECT_FIELD_NAME  # Set by django.contrib.auth
 
@@ -34,13 +34,13 @@ class AccessMixin(object):
         """
         Override this method to customize the login_url.
         """
-        if self.login_url is None:
+        login_url = self.login_url or settings.LOGIN_URL
+        if not login_url:
             raise ImproperlyConfigured(
-                "%(cls)s is missing the login_url. "
-                "Define %(cls)s.login_url or override "
+                "Define %(cls)s.login_url or settings.LOGIN_URL or override "
                 "%(cls)s.get_login_url()." % {"cls": self.__class__.__name__})
 
-        return force_text(self.login_url)
+        return force_text(login_url)
 
     def get_redirect_field_name(self):
         """

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -75,4 +75,5 @@ urlpatterns += patterns(
     'django.contrib.auth.views',
     # login page, required by some tests
     url(r'^accounts/login/$', 'login', {'template_name': 'blank.html'}),
+    url(r'^auth/login/$', 'login', {'template_name': 'blank.html'}),
 )


### PR DESCRIPTION
`AccessMixin.login_url` is defined at import time according to `settings.LOGIN_URL` and this applies for all request. There's no way to change it. 

Sometimes it's neccessary to be able to change settings on the fly; for example during testing. Django offers a way to override settings via `django.test.utils.override_settings` but changing `settings.LOGIN_URL` won't affect views that inherit from `AccessMixin` because their `login_url` was set at import time.

This fixes #91.
