### PR TITLE
Added an ExtraContextMixin

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -22,6 +22,7 @@ Direct Contributors
 * Markus Zapke-Gründemann
 * Kamil Gałuszka
 * Danilo Bargen
+* Kit Sunde
 
 Other Contributors
 ==================

--- a/braces/views.py
+++ b/braces/views.py
@@ -401,6 +401,28 @@ class SetHeadlineMixin(object):
         return self.headline
 
 
+class ExtraContextMixin(object):
+    """
+    Mixin allows you to set extra context through a static property on the
+    class or programmatically by overloading the get_extra_context method.
+    """
+    extra_context = None
+
+    def get_context_data(self, **kwargs):
+        kwargs = super(ExtraContextMixin, self).get_context_data(**kwargs)
+        kwargs.update(self.get_extra_context())
+        return kwargs
+
+    def get_extra_context(self):
+        if self.extra_context is None:
+            raise ImproperlyConfigured(
+                "%(cls)s is missing extra_context. "
+                "Define %(cls)s.extra_context, or override "
+                "%(cls)s.get_extra_context()." % {"cls": self.__class__.__name__}
+            )
+        return self.extra_context
+
+
 class SelectRelatedMixin(object):
     """
     Mixin allows you to provide a tuple or list of related models to

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -44,6 +44,38 @@ Dynamic Example
 In both usages, in the template, just print out ``{{ headline }}`` to show the generated headline.
 
 
+.. _ExtraContextMixin:
+
+ExtraContextMixin
+-----------------
+
+The ``ExtraContextMixin`` allows us to *statically* or *programmatically* add statically to the context which is useful in cases like navigation highlighting.
+
+
+::
+
+    # views.py
+
+    from braces.views import ExtraContextMixin
+
+
+    class ContextTemplateView(SetHeadlineMixin, TemplateView):
+        pass
+
+
+::
+
+    # urls.py
+
+    urlpatterns = patterns(
+        '',
+        url(r'^$',
+            ContextTemplateView.as_view(
+                template_name='index.html',
+                extra_context={'nav_home': True}
+            ),
+            name='index')
+    )
 
 
 .. _SelectRelatedMixin:

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -3,7 +3,7 @@ import mock
 from django import test
 from django.core.exceptions import ImproperlyConfigured
 from braces.views import (SetHeadlineMixin, FormValidMessageMixin,
-                          FormInvalidMessageMixin)
+                          FormInvalidMessageMixin, ExtraContextMixin)
 from .models import Article, CanonicalArticle
 from .helpers import TestViewHelper
 from .views import (CreateArticleView, ArticleListView, AuthorDetailView,
@@ -78,6 +78,29 @@ class TestSetHeadlineMixin(test.TestCase):
 
         mixin.headline = "Test headline"
         self.assertEqual("Test headline", mixin.get_headline())
+
+
+class TestExtraContextMixin(test.TestCase):
+    """
+    Tests for ExtraContextMixin.
+    """
+    def test_context_data(self):
+        """
+        Tests if mixin adds proper headline to template context.
+        """
+        resp = self.client.get('/context/')
+        self.assertEqual(True, resp.context['test'])
+
+    def test_get_extra_context(self):
+        """
+        Tests if get_extra_context() method works correctly.
+        """
+        mixin = ExtraContextMixin()
+        with self.assertRaises(ImproperlyConfigured):
+            mixin.get_extra_context()
+
+        mixin.extra_context = {'text': 'context'}
+        self.assertEqual({'text': 'context'}, mixin.get_extra_context())
 
 
 class TestCsrfExemptMixin(test.TestCase):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -39,6 +39,9 @@ urlpatterns = patterns(
     url(r'^headline/$', views.HeadlineView.as_view(), name='headline'),
     url(r'^headline/(?P<s>[\w-]+)/$', views.DynamicHeadlineView.as_view()),
 
+    # ExtraContextMixin tests
+    url(r'^context/$', views.ContextView.as_view(), name='context'),
+
     # PermissionRequiredMixin tests
     url(r'^permission_required/$', views.PermissionRequiredView.as_view()),
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -174,6 +174,14 @@ class HeadlineView(views.SetHeadlineMixin, TemplateView):
     headline = "Test headline"
 
 
+class ContextView(views.ExtraContextMixin, TemplateView):
+    """
+    View for testing ExtraContextMixin.
+    """
+    template_name = 'blank.html'
+    extra_context = {'test': True}
+
+
 class DynamicHeadlineView(views.SetHeadlineMixin, TemplateView):
     """
     View for testing SetHeadlineMixin's get_headline() method.


### PR DESCRIPTION
Hello!

This allows the user pass in a static context without needing to override `get_context_data` in their own views. We specifically use something like this to pass in active nav variables for menu highlighting.

Bundled with tests and doc updates. :)
