### PR TITLE
AllVerbsMixin: call a method for all HTTP verbs

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -798,3 +798,21 @@ class FormMessagesMixin(FormValidMessageMixin, FormInvalidMessageMixin):
     FormInvalidMessageMixin.
     """
     pass
+
+
+class AllVerbsMixin(object):
+    """Call a single method for all HTTP verbs.
+
+    The name of the method should be specified using the class attribute
+    ``all_handler``. The default value of this attribute is 'all'.
+    """
+    all_handler = 'all'
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.all_handler:
+            raise ImproperlyConfigured(
+                "{cls} requires the all_handler attribute to be set.".format(
+                    cls=self.__class__.__name__))
+
+        handler = getattr(self, self.all_handler, self.http_method_not_allowed)
+        return handler(request, *args, **kwargs)

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -404,3 +404,37 @@ class TestFormMessageMixins(test.TestCase):
         mixin = FormInvalidMessageMixin()
         mixin.form_invalid_message = u'Bad øø'
         self.assertEqual(u'Bad øø', mixin.get_form_invalid_message())
+
+
+class TestAllVerbsMixin(test.TestCase):
+    def setUp(self):
+        self.url = "/all_verbs/"
+        self.no_handler_url = "/all_verbs_no_handler/"
+
+    def test_options(self):
+        response = self.client.options(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_head(self):
+        response = self.client.head(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_put(self):
+        response = self.client.put(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete(self):
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_all_handler(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/all_verbs_no_handler/')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -76,6 +76,10 @@ urlpatterns = patterns(
 
     # FormMessagesMixin tests
     url(r'form_messages/$', views.FormMessagesView.as_view()),
+
+    # AllVerbsMixin tests
+    url(r'all_verbs/$', views.AllVerbsView.as_view()),
+    url(r'all_verbs_no_handler/$', views.AllVerbsView.as_view(all_handler=None)),
 )
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -264,3 +264,8 @@ class UserPassesTestView(views.UserPassesTestMixin, OkView):
 
 class UserPassesTestNotImplementedView(views.UserPassesTestMixin, OkView):
     pass
+
+
+class AllVerbsView(views.AllVerbsMixin, View):
+    def all(self, request, *args, **kwargs):
+        return HttpResponse('All verbs return this!')


### PR DESCRIPTION
This refers to issue #97.

The dispatch method will extract the attribute specified by the class attribute "all_handler", the default value of which is "all". The dispatch method then calls this method, without checking what the HTTP verb is. If "all_handler" is not specified (technically if it evaluates to False) then ImproperlyConfigured exception is raised.

Tests are in tests/test_other_mixins.py::TestAllVerbsMixin.

I was able to run the tests using py2.7-d1.4, py2.7-d1.5, and py2.7-d1.6. I don't have the other two interpreters installed on my system. I will check them soon.
