### PR TITLE
Added a MessageMixin.

### DIFF
--- a/braces/views.py
+++ b/braces/views.py
@@ -1,4 +1,5 @@
 import six
+from types import FunctionType
 
 from django.conf import settings
 from django.contrib import messages
@@ -13,6 +14,7 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
+from django.utils.functional import curry
 from django.views.decorators.csrf import csrf_exempt
 
 ## Django 1.5+ compat
@@ -784,7 +786,40 @@ class CanonicalSlugDetailMixin(object):
         return self.get_object().slug
 
 
-class FormValidMessageMixin(object):
+class _MessageAPIWrapper(object):
+    """
+    Wrap the django.contrib.messages.api module to automatically pass a given
+    request object as the first parameter of function calls.
+    """
+    API = set([
+        'add_message', 'get_messages',
+        'get_level', 'set_level',
+        'debug', 'info', 'success', 'warning', 'error',
+    ])
+    def __init__(self, request):
+        for name in self.API:
+            api_fn = getattr(messages.api, name)
+            setattr(self, name, curry(api_fn, request))
+
+
+class _MessageDescriptor(object):
+    """
+    A descriptor that binds the _MessageAPIWrapper to the view's request.
+    """
+    def __get__(self, instance, owner):
+        return _MessageAPIWrapper(instance.request)
+
+
+class MessageMixin(object):
+    """
+    Add a `messages` attribute on the view instance that wraps
+    `django.contrib .messages`, automatically passing the current request
+    object.
+    """
+    messages = _MessageDescriptor()
+
+
+class FormValidMessageMixin(MessageMixin):
     """
     Mixin allows you to set static message which is displayed by
     Django's messages framework through a static property on the class
@@ -818,12 +853,12 @@ class FormValidMessageMixin(object):
         get_form_valid_message, we have access to the newly saved object.
         """
         response = super(FormValidMessageMixin, self).form_valid(form)
-        messages.success(self.request, self.get_form_valid_message(),
+        self.messages.success(self.get_form_valid_message(),
                          fail_silently=True)
         return response
 
 
-class FormInvalidMessageMixin(object):
+class FormInvalidMessageMixin(MessageMixin):
     """
     Mixin allows you to set static message which is displayed by
     Django's messages framework through a static property on the class
@@ -853,7 +888,7 @@ class FormInvalidMessageMixin(object):
 
     def form_invalid(self, form):
         response = super(FormInvalidMessageMixin, self).form_invalid(form)
-        messages.error(self.request, self.get_form_invalid_message(),
+        self.messages.error(self.get_form_invalid_message(),
                        fail_silently=True)
         return response
 

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -47,7 +47,7 @@ In both usages, in the template, just print out ``{{ headline }}`` to show the g
 .. _StaticContextMixin:
 
 StaticContextMixin
------------------
+------------------
 
 The ``StaticContextMixin`` allows you to easily set static context data by using the ``static_context`` property. While it's possible to override
 the ``StaticContextMixin.get_static_context method``, it's not very practical. If you have a need to override a method for dynamic context data it's
@@ -108,6 +108,8 @@ A simple mixin which allows you to specify a list or tuple of foreign key fields
         select_related = ["user"]
         template_name = "profiles/detail.html"
 
+.. _select_related: https://docs.djangoproject.com/en/1.5/ref/models/querysets/#select-related
+
 
 .. _PrefetchRelatedMixin:
 
@@ -129,6 +131,8 @@ A simple mixin which allows you to specify a list or tuple of reverse foreign ke
         model = User
         prefetch_related = ["post_set"]  # where the Post model has an FK to the User model as an author.
         template_name = "users/detail.html"
+
+.. _prefetch_related: https://docs.djangoproject.com/en/1.5/ref/models/querysets/#prefetch-related
 
 
 .. _JSONResponseMixin:
@@ -367,5 +371,45 @@ Or by overriding the ``get_canonical_slug()`` method on the view:
 
 Given the same Article as before, this will generate urls of `http://127.0.0.1:8000/article/1-my-blog-hello-world` and `http://127.0.0.1:8000/article/1-uryyb-jbeyq`, respectively.
 
-.. _select_related: https://docs.djangoproject.com/en/1.5/ref/models/querysets/#select-related
-.. _prefetch_related: https://docs.djangoproject.com/en/1.5/ref/models/querysets/#prefetch-related
+
+.. _MessageMixin:
+
+MessageMixin
+------------
+
+.. versionadded:: 1.4
+
+A mixin that adds a ``messages`` attribute on the view which acts as a wrapper
+to ``django.contrib.messages`` and passes the ``request`` object automatically.
+
+    .. warning::
+        If you're using Django 1.4, then the ``message`` attribute is only
+        available after the base view's ``dispatch`` method has been called
+        (so our second example would not work for instance).
+
+::
+
+    from django.contrib import messages
+    from django.contrib.messages.views import MessageMixin
+    from django.views.generic import TemplateView
+
+    class MyView(MessageMixin, TemplateView):
+        """
+        This view will add a debug message which can then be displayed in the
+        template.
+        """
+        template_name = "my_template.html"
+
+        def get(self, request, *args, **kwargs):
+            self.messages.debug("This is a debug message.")
+            return super(MyView, self).get(request, *args, **kwargs)
+
+    class OnlyWarningView(MessageMixin, TemplateView):
+        """
+        This view will only show messages that have a level above `warning`.
+        """
+        template_name = "my_template.html"
+
+        def dispatch(self, request, *args, **kwargs):
+            self.messages.set_level(messages.WARNING)
+            return super(OnlyWarningView, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
As mentionned to Kenneth on twitter, I originally considered adding this to Django itself but I think this works nicer as a third party app.

All tests seem to pass on my machine, except those involving Python 2.6 because I don't have it installed.

Support for Django 1.4 is a bit tricky because the `request` attribute is only set on the view during `View.dispatch()` which means it's not available very early.
I "solved" it with a big warning box in the documentation and skipping a test that was checking just for that.
