### PR TITLE
allow ugettext_lazy-wrapped strings for form messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To run the test suite, execute the following in your shell (Django install is re
 * Fixed bug in `GroupRequiredMixin` which now correctly checks for group membership against a list.
 * Added new `StaticContextMixin` mixin which lets you pass in `static_context` as a property of the view.
 * Added new `AnonymousRequiredMixin` which redirects authenticated users to another view.
+* `FormValidMessageMixin`, `FormInvalidMessageMixin`, and `FormMessagesMixin` all allow `ugettext_lazy`-wrapped strings. 
 
 ### 1.3.1
 

--- a/braces/views.py
+++ b/braces/views.py
@@ -13,6 +13,7 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
+from django.utils.functional import Promise
 from django.views.decorators.csrf import csrf_exempt
 
 ## Django 1.5+ compat
@@ -804,13 +805,14 @@ class FormValidMessageMixin(object):
                 '{0}.get_form_valid_message().'.format(self.__class__.__name__)
             )
 
-        if not isinstance(self.form_valid_message, six.string_types):
+        if not isinstance(self.form_valid_message,
+                          (six.string_types, six.text_type, Promise)):
             raise ImproperlyConfigured(
                 '{0}.form_valid_message must be a str or unicode '
                 'object.'.format(self.__class__.__name__)
             )
 
-        return self.form_valid_message
+        return force_text(self.form_valid_message)
 
     def form_valid(self, form):
         """
@@ -844,12 +846,12 @@ class FormInvalidMessageMixin(object):
                     self.__class__.__name__))
 
         if not isinstance(self.form_invalid_message,
-                          (six.string_types, six.text_type)):
+                          (six.string_types, six.text_type, Promise)):
             raise ImproperlyConfigured(
                 '{0}.form_invalid_message must be a str or unicode '
                 'object.'.format(self.__class__.__name__))
 
-        return self.form_invalid_message
+        return force_text(self.form_invalid_message)
 
     def form_invalid(self, form):
         response = super(FormInvalidMessageMixin, self).form_invalid(form)

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import mock
 from django import test
 from django.core.exceptions import ImproperlyConfigured

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,6 +2,7 @@ import codecs
 
 from django.contrib.auth.models import User
 from django.http import HttpResponse
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import (View, UpdateView, FormView, TemplateView,
                                   ListView, DetailView, CreateView)
 
@@ -267,8 +268,8 @@ class ModelCanonicalSlugDetailView(views.CanonicalSlugDetailMixin,
 
 class FormMessagesView(views.FormMessagesMixin, CreateView):
     form_class = ArticleForm
-    form_invalid_message = 'Invalid'
-    form_valid_message = 'Valid'
+    form_invalid_message = _('Invalid')
+    form_valid_message = _('Valid')
     model = Article
     success_url = '/form_messages/'
     template_name = 'form.html'


### PR DESCRIPTION
Closes #107.
- You can use:

``` python
class SomeView(FormMessagesMixin, DetailView):
    form_valid_message = _('You did it!')
```
