### PR TITLE
Implemented redirect_unauthenticated_users on LoginRequiredMixin

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -51,9 +51,11 @@ class LoginRequiredMixin(AccessMixin):
         combined with CsrfExemptMixin - which in that case should
         be the left-most mixin.
     """
+    redirect_unauthenticated_users = False
+
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated():
-            if self.raise_exception:
+            if self.raise_exception and not self.redirect_unauthenticated_users:
                 raise PermissionDenied  # return a forbidden response
             else:
                 return redirect_to_login(request.get_full_path(),

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -46,6 +46,8 @@ This mixin is rather simple and is generally the first inherited class in any vi
         def get(self, request):
             return self.render_to_response({})
 
+An optional class attribute of ``redirect_unauthenticated_users`` can be set to ``True`` if you are using another ``access`` mixin with ``raise_exception`` set to ``True``. This will redirect to the login page if the user is not authenticated, but raises an exception if they are but do not have the required access defined by the other mixins. This defaults to ``False``.
+
 .. _PermissionRequiredMixin:
 
 PermissionRequiredMixin

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -147,6 +147,14 @@ class TestLoginRequiredMixin(TestViewHelper, test.TestCase):
         assert resp.status_code == 200
         assert force_text(resp.content) == 'OK'
 
+    def test_anonymous_redirects(self):
+        resp = self.dispatch_view(
+                self.build_request(path=self.view_url),
+                raise_exception=True,
+                redirect_unauthenticated_users=True)
+        assert resp.status_code == 302
+        assert resp['Location'] == '/accounts/login/?next=/login_required/'
+
 
 class TestAnonymousRequiredMixin(TestViewHelper, test.TestCase):
     """


### PR DESCRIPTION
An implementation of `redirect_unauthenticated_users` on the `LoginRequiredMixin`, with simple docs and tests.
