### PR TITLE
Add CurentSiteMixin.

### DIFF
--- a/braces/views/_queries.py
+++ b/braces/views/_queries.py
@@ -1,3 +1,4 @@
+from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 
 
@@ -120,3 +121,13 @@ class OrderableListMixin(object):
         """
         unordered_queryset = super(OrderableListMixin, self).get_queryset()
         return self.get_ordered_queryset(unordered_queryset)
+
+
+class CurrentSiteMixin(object):
+    site_field = 'site'
+
+    def get_queryset(self):
+        queryset = super(CurrentSiteMixin, self).get_queryset()
+        queryset = queryset.filter(
+            **{self.site_field: Site.objects.get_current()})
+        return queryset


### PR DESCRIPTION
This is a mixin for making sure the rows returned by the queryset is only for the current Site.  Currently, I'm using it with `ListView`s.  I just did this because I needed it but I'm not sure if this already exists or if there is a better way of doing this.

Anyway, let me know if there are any interests in this one and I'll continue working on this -- I'll figure out how to make it work for content that can be added to multiple sites, and add tests and documentation.  Or, if this already exists somewhere or there's a better way of doing this, please let me know as well so I can use that one instead.
