### PR TITLE
TBD: access mixins: support for custom exceptions

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -16,7 +16,7 @@ class AccessMixin(object):
     functionality.
     """
     login_url = None
-    raise_exception = False  # Default whether to raise an exception to none
+    raise_exception = False
     redirect_field_name = REDIRECT_FIELD_NAME  # Set by django.contrib.auth
     redirect_unauthenticated_users = False
 
@@ -50,7 +50,7 @@ class AccessMixin(object):
                     and issubclass(self.raise_exception, Exception):
                 raise self.raise_exception
             if callable(self.raise_exception):
-                ret = self.raise_exception()
+                ret = self.raise_exception(request)
                 if isinstance(ret, (HttpResponse, StreamingHttpResponse)):
                     return ret
             raise PermissionDenied

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -5,7 +5,8 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.http import HttpResponseRedirect
+from django.http import (HttpResponse, HttpResponseRedirect,
+                         StreamingHttpResponse)
 from django.utils.encoding import force_text
 
 
@@ -50,8 +51,7 @@ class AccessMixin(object):
                 raise self.raise_exception
             if callable(self.raise_exception):
                 ret = self.raise_exception()
-                # XXX: check for isinstance(ret, (HttpResponse, StreamingHttpResponse))?
-                if ret is not None:
+                if isinstance(ret, (HttpResponse, StreamingHttpResponse)):
                     return ret
             raise PermissionDenied
 

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -5,9 +5,16 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.http import (HttpResponse, HttpResponseRedirect,
-                         StreamingHttpResponse)
+from django.http import HttpResponse, HttpResponseRedirect
 from django.utils.encoding import force_text
+
+# StreamingHttpResponse has been added in 1.5, and gets used for verification
+# only.
+try:
+    from django.http import StreamingHttpResponse
+except ImportError:
+    class StreamingHttpResponse:
+        pass
 
 
 class AccessMixin(object):

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -18,8 +18,8 @@ permission is denied:
     * A subclass of ``Exception``: raises this exception.
     * A callable: gets called with the ``request`` argument.
       The function has to return a ``HttpResponse`` or
-      ``StreamingHttpResponse``, otherwise a ``PermissionDenied`` exception
-      gets raised.
+      ``StreamingHttpResponse`` (Django 1.5+), otherwise a ``PermissionDenied``
+      exception gets raised.
 
 This gets done in ``handle_no_permission``, which can be overridden itself.
 

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -6,10 +6,22 @@ These mixins all control a user's access to a given view. Since many of them ext
 ::
 
     login_url = settings.LOGIN_URL
-    redirect_field_name = REDIRECT_FIELD_NAME
     raise_exception = False
+    redirect_field_name = REDIRECT_FIELD_NAME
+    redirect_unauthenticated_users = False
 
-The ``raise_exception`` attribute will cause the view to raise a ``PermissionDenied`` exception if it is set to ``True``, otherwise the view will redirect to the login view provided.
+The ``raise_exception`` attribute allows for these scenarios, in case a
+permission is denied:
+
+    * ``False`` (default): redirects to the provided login view.
+    * ``True``: raises a ``PermissionDenied`` exception.
+    * A subclass of ``Exception``: raises this exception.
+    * A callable: gets called with the ``request`` argument.
+      The function has to return a ``HttpResponse`` or
+      ``StreamingHttpResponse``, otherwise a ``PermissionDenied`` exception
+      gets raised.
+
+This gets done in ``handle_no_permission``, which can be overridden itself.
 
 .. contents::
 

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -88,7 +88,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         def func():
             pass
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(PermissionDenied):
             self.dispatch_view(req, raise_exception=func)
 
     def test_raise_func_response(self):
@@ -105,6 +105,20 @@ class _TestAccessBasicsMixin(TestViewHelper):
         resp = self.dispatch_view(req, raise_exception=func)
         assert resp.status_code == 200
         assert force_text(resp.content) == 'CUSTOM'
+
+    def test_raise_func_false(self):
+        """
+        A custom response should be returned if user is not authorized and
+        raise_exception attribute is set to a function that returns a response.
+        """
+        user = self.build_unauthorized_user()
+        req = self.build_request(user=user, path=self.view_url)
+
+        def func():
+            return False
+
+        ret = self.dispatch_view(req, raise_exception=func)
+        assert ret is False
 
     def test_raise_func_raises(self):
         """

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -193,6 +193,22 @@ class _TestAccessBasicsMixin(TestViewHelper):
         self.assertRedirects(resp, u'/auth/login/?next={0}'.format(
             self.view_url))
 
+    def test_redirect_unauthenticated(self):
+        resp = self.dispatch_view(
+                self.build_request(path=self.view_url),
+                raise_exception=True,
+                redirect_unauthenticated_users=True)
+        assert resp.status_code == 302
+        assert resp['Location'] == '/accounts/login/?next={0}'.format(
+            self.view_url)
+
+    def test_redirect_unauthenticated_false(self):
+        with self.assertRaises(PermissionDenied):
+            self.dispatch_view(
+                self.build_request(path=self.view_url),
+                raise_exception=True,
+                redirect_unauthenticated_users=False)
+
 
 class TestLoginRequiredMixin(TestViewHelper, test.TestCase):
     """
@@ -216,14 +232,6 @@ class TestLoginRequiredMixin(TestViewHelper, test.TestCase):
         resp = self.client.get(self.view_url)
         assert resp.status_code == 200
         assert force_text(resp.content) == 'OK'
-
-    def test_anonymous_redirects(self):
-        resp = self.dispatch_view(
-                self.build_request(path=self.view_url),
-                raise_exception=True,
-                redirect_unauthenticated_users=True)
-        assert resp.status_code == 302
-        assert resp['Location'] == '/accounts/login/?next=/login_required/'
 
 
 class TestAnonymousRequiredMixin(TestViewHelper, test.TestCase):

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -108,8 +108,8 @@ class _TestAccessBasicsMixin(TestViewHelper):
 
     def test_raise_func_false(self):
         """
-        A custom response should be returned if user is not authorized and
-        raise_exception attribute is set to a function that returns a response.
+        PermissionDenied should be raised, if a custom raise_exception
+        function does not return HttpResponse or StreamingHttpResponse.
         """
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
@@ -117,8 +117,8 @@ class _TestAccessBasicsMixin(TestViewHelper):
         def func():
             return False
 
-        ret = self.dispatch_view(req, raise_exception=func)
-        assert ret is False
+        with self.assertRaises(PermissionDenied):
+            self.dispatch_view(req, raise_exception=func)
 
     def test_raise_func_raises(self):
         """

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -85,7 +85,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
 
-        def func():
+        def func(request):
             pass
 
         with self.assertRaises(PermissionDenied):
@@ -99,7 +99,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
 
-        def func():
+        def func(request):
             return HttpResponse("CUSTOM")
 
         resp = self.dispatch_view(req, raise_exception=func)
@@ -114,7 +114,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
 
-        def func():
+        def func(request):
             return False
 
         with self.assertRaises(PermissionDenied):
@@ -129,7 +129,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
 
-        def func():
+        def func(request):
             raise Http404
 
         with self.assertRaises(Http404):


### PR DESCRIPTION
I wanted to use a custom exception with `SuperuserRequiredMixin` (`Http404`) and added support for it.

`raise_exception` can now be `True`, `False`, a custom exception or a callable (that should return a response).

I have then factored the no-permission handling into a separate function, and moved `redirect_unauthenticated_users` to the base mixin.

This does not include any documentation changes yet, because I wanted to gather feedback on it first.

E.g., I am not sure if `handle_no_permission` should fall back to raising an exception for any non-HTTP-response (`not isinstance(ret, (HttpResponse, StreamingHttpResponse))`).