### PR TITLE
Do not blindly override select_related or prefetch_related.

### DIFF
--- a/braces/views/_queries.py
+++ b/braces/views/_queries.py
@@ -25,6 +25,8 @@ class SelectRelatedMixin(object):
         # Get the current queryset of the view
         queryset = super(SelectRelatedMixin, self).get_queryset()
 
+        if not self.select_related:
+            return queryset
         return queryset.select_related(*self.select_related)
 
 
@@ -52,6 +54,8 @@ class PrefetchRelatedMixin(object):
         # Get the current queryset of the view
         queryset = super(PrefetchRelatedMixin, self).get_queryset()
 
+        if not self.prefetch_related:
+            return queryset
         return queryset.prefetch_related(*self.prefetch_related)
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -187,6 +187,15 @@ class ArticleListView(views.SelectRelatedMixin, ListView):
     select_related = ('author',)
 
 
+class ArticleListViewWithCustomQueryset(views.SelectRelatedMixin, ListView):
+    """
+    Another list view for articles, required to test SelectRelatedMixin.
+    """
+    queryset = Article.objects.select_related('author').prefetch_related('article_set')
+    template_name = 'blank.html'
+    select_related = ()
+
+
 class FormWithUserKwargView(views.UserFormKwargsMixin, FormView):
     """
     View for testing UserFormKwargsMixin.


### PR DESCRIPTION
Currently, when empty `select_related` or `prefetch_related` attributes are given to subclasses of `SelectRelatedMixin` and `PrefetchRelatedMixin`, these mixins issue an empty call to `select_related()` and `prefetch_related()`. Up to Django 1.6 (included), these calls are not chainable. Hence, if the original queryset already has select_related or prefetch_related fields, the mixins cancel them.

Use case: we have a custom ListView that inherits from SelectRelatedMixin. Most subclasses define a queryset with no select_related or with a custom one through a `select_related` attribute. This is fine. However, for some other views, we re-use a manager that does the right select_related (keeping the definition of select_related fields in a single place) : 

```
class CustomListView(ListView, SelectRelatedMixin):
    queryset = Article.objects.with_list_select_related()

class ThingListView(CustomListView):
    queryset = Thing.objects.list_select_related()
```
