### PR TITLE
call redirect_url on LOGIN_REDIRECT_URL

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -5,6 +5,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import HttpResponseRedirect
+from django.shortcuts import resolve_url
 from django.utils.encoding import force_text
 
 
@@ -100,7 +101,7 @@ class AnonymousRequiredMixin(object):
                 '{0}.authenticated_redirect_url or override '
                 '{0}.get_authenticated_redirect_url().'.format(
                     self.__class__.__name__))
-        return self.authenticated_redirect_url
+        return resolve_url(self.authenticated_redirect_url)
 
 
 class PermissionRequiredMixin(AccessMixin):


### PR DESCRIPTION
django has a standard where on LOGIN_REDIRECT_URL settings it's
permitted to use url names like 'namespace:urlname' without using
reverse_lazy on it (given it could be troublesome to import that
directly in settings), so calling redirect_url(LOGIN_REDIRECT_URL)
fixes this problem. This calling standard is also done in the
django.contrib.auth.login view, so we should follow that standard.