### PR TITLE
Feature/sslrequiredmixin

### DIFF
--- a/braces/views/__init__.py
+++ b/braces/views/__init__.py
@@ -8,7 +8,8 @@ from ._access import (
     PermissionRequiredMixin,
     StaffuserRequiredMixin,
     SuperuserRequiredMixin,
-    UserPassesTestMixin
+    UserPassesTestMixin,
+    SSLRequiredMixin
 )
 from ._ajax import (
     AjaxResponseMixin,
@@ -64,5 +65,6 @@ __all__ = [
     'SuccessURLRedirectListMixin',
     'SuperuserRequiredMixin',
     'UserFormKwargsMixin',
-    'UserPassesTestMixin'
+    'UserPassesTestMixin',
+    'SSLRequiredMixin'
 ]

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -1,10 +1,12 @@
+import re
 import six
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.http import HttpResponseRedirect
+from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
+                         Http404)
 from django.utils.encoding import force_text
 
 
@@ -391,3 +393,30 @@ class StaffuserRequiredMixin(AccessMixin):
 
         return super(StaffuserRequiredMixin, self).dispatch(
             request, *args, **kwargs)
+
+
+class SSLRequiredMixin(object):
+    """
+    Simple mixin that allows you to force a view to be accessed
+    via https.
+    """
+    raise_exception = False  # Default whether to raise an exception to none
+
+    def dispatch(self, request, *args, **kwargs):
+        if getattr(settings, 'DEBUG', False):
+            return super(SSLRequiredMixin, self).dispatch(
+                request, *args, **kwargs)
+
+        if not request.is_secure():
+            if self.raise_exception:
+                raise Http404
+
+            return HttpResponsePermanentRedirect(
+                self._build_https_url(request))
+
+        return super(SSLRequiredMixin, self).dispatch(request, *args, **kwargs)
+
+    def _build_https_url(self, request):
+        """ Get the full url, replace http with https """
+        url = request.build_absolute_uri(request.get_full_path())
+        return re.sub(r'^http', 'https', url)

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -297,6 +297,47 @@ Similar to :ref:`SuperuserRequiredMixin`, this mixin allows you to require a use
 
         template_name = u"path/to/template.html"
 
+.. _SSLRequiredMixin
+
+SSLRequiredMixin
+----------------
+
+.. versionadded:: 1.8.0
+
+Simple view mixin that requires the incoming request to be secure by checking
+Django's `request.is_secure()` method. By default the mixin will return a
+permanent (301) redirect to the https verison of the current url. Optionally
+you can set `raise_exception=True` and a 404 will be raised.
+
+Standard Django Usage
+^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    from django.views import TemplateView
+
+    from braces.views import SSLRequiredMixin
+
+
+    class SomeSecureView(SSLRequiredMixin, TemplateView):
+        """ Redirects from http -> https """
+        template_name = "path/to/template.html"
+
+Standard Django Usage
+^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    from django.views import TemplateView
+
+    from braces.views import SSLRequiredMixin
+
+
+    class SomeSecureView(SSLRequiredMixin, TemplateView):
+        """ http request would raise 404. https renders view """
+        raise_exception = True
+        template_name = "path/to/template.html"
+
 .. _Daniel Sokolowski: https://github.com/danols
 .. _code here: https://github.com/lukaszb/django-guardian/issues/48
 .. _user_passes_test: https://docs.djangoproject.com/en/1.6/topics/auth/default/#django.contrib.auth.decorators.user_passes_test

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@
 Changelog
 =========
 
-* :feature:`171` New SSLRequiredMixin. Redirect http -> https.
+* :feature:`171` New :ref:`SSLRequiredMixin`. Redirect http -> https.
 * :release:`1.8.0 <2015-04-16>`
 * :bug:`164` Use `resolve_url` to handle `LOGIN_REDIRECT_URL`s in `settings.py` that are just URL names.
 * :bug:`130` New attribute on :ref:`JSONResponseMixin` to allow setting a custom JSON encoder class.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+* :feature:`171` New SSLRequiredMixin. Redirect http -> https.
+* :release:`1.8.0 <2015-04-16>`
 * :bug:`164` Use `resolve_url` to handle `LOGIN_REDIRECT_URL`s in `settings.py` that are just URL names.
 * :bug:`130` New attribute on :ref:`JSONResponseMixin` to allow setting a custom JSON encoder class.
 * :bug:`131` New attribute on :ref:`LoginRequiredMixin` so it's possible to redirect unauthenticated users while

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -484,7 +484,10 @@ class TestSSLRequiredMixin(test.TestCase):
     def test_ssl_redirection(self):
         self.view_class.raise_exception = False
         resp = self.client.get(self.view_url)
-        self.assertEqual('https', resp.url[:5])
+        self.assertEqual(301, resp.status_code)
+        resp = self.client.get(self.view_url, follow=True)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('https', resp.request.get('wsgi.url_scheme'))
 
     def test_raises_exception(self):
         self.view_class.raise_exception = True
@@ -492,5 +495,7 @@ class TestSSLRequiredMixin(test.TestCase):
         self.assertEqual(404, resp.status_code)
 
     def test_https_does_not_redirect(self):
+        self.view_class.raise_exception = False
         resp = self.client.get(self.view_url, secure=True)
         self.assertEqual(200, resp.status_code)
+        self.assertEqual('https', resp.request.get('wsgi.url_scheme'))

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -12,7 +12,8 @@ from .helpers import TestViewHelper
 from .views import (PermissionRequiredView, MultiplePermissionsRequiredView,
                     SuperuserRequiredView, StaffuserRequiredView,
                     LoginRequiredView, GroupRequiredView, UserPassesTestView,
-                    UserPassesTestNotImplementedView, AnonymousRequiredView)
+                    UserPassesTestNotImplementedView, AnonymousRequiredView,
+                    SSLRequiredView)
 
 
 class _TestAccessBasicsMixin(TestViewHelper):
@@ -474,3 +475,18 @@ class TestUserPassesTestMixin(_TestAccessBasicsMixin, test.TestCase):
             view.dispatch(
                 self.build_request(path=self.view_not_implemented_url),
                 raise_exception=True)
+
+
+class TestSSLRequiredMixin(test.TestCase):
+    view_class = SSLRequiredView
+    view_url = '/sslrequired/'
+
+    def test_ssl_redirection(self):
+        self.view_class.raise_exception = False
+        resp = self.client.get(self.view_url)
+        self.assertEqual('https', resp.url[:5])
+
+    def test_raises_exception(self):
+        self.view_class.raise_exception = True
+        resp = self.client.get(self.view_url)
+        self.assertEqual(404, resp.status_code)

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -490,3 +490,7 @@ class TestSSLRequiredMixin(test.TestCase):
         self.view_class.raise_exception = True
         resp = self.client.get(self.view_url)
         self.assertEqual(404, resp.status_code)
+
+    def test_https_does_not_redirect(self):
+        resp = self.client.get(self.view_url, secure=True)
+        self.assertEqual(200, resp.status_code)

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -149,9 +149,8 @@ class TestLoginRequiredMixin(TestViewHelper, test.TestCase):
 
     def test_anonymous_redirects(self):
         resp = self.dispatch_view(
-                self.build_request(path=self.view_url),
-                raise_exception=True,
-                redirect_unauthenticated_users=True)
+            self.build_request(path=self.view_url), raise_exception=True,
+            redirect_unauthenticated_users=True)
         assert resp.status_code == 302
         assert resp['Location'] == '/accounts/login/?next=/login_required/'
 

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 
 import pytest
 
-import django
 from django import test
+from django import VERSION as DJANGO_VERSION
 from django.test.utils import override_settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.core.urlresolvers import reverse_lazy
@@ -484,7 +484,7 @@ class TestSSLRequiredMixin(test.TestCase):
     view_class = SSLRequiredView
     view_url = '/sslrequired/'
 
-    @pytest.mark.skipif(django.VERSION[:2] < (1, 7),
+    @pytest.mark.skipif(DJANGO_VERSION[:2] < (1, 7),
                         reason='Djanog 1.6 and below behave this differently')
     def test_ssl_redirection_django_17_up(self):
         self.view_class.raise_exception = False
@@ -494,7 +494,7 @@ class TestSSLRequiredMixin(test.TestCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual('https', resp.request.get('wsgi.url_scheme'))
 
-    @pytest.mark.skipif(django.VERSION[:2] > (1, 6),
+    @pytest.mark.skipif(DJANGO_VERSION[:2] > (1, 6),
                         reason='Django 1.7 and above behave differently')
     def test_ssl_redirection_django_16_down(self):
         self.view_class.raise_exception = False
@@ -516,7 +516,7 @@ class TestSSLRequiredMixin(test.TestCase):
         self.assertEqual(200, resp.status_code)
 
     @pytest.mark.skipif(
-        django.VERSION[:2] < (1, 7),
+        DJANGO_VERSION[:2] < (1, 7),
         reason='Djanog 1.6 and below does not have the secure=True option')
     def test_https_does_not_redirect_django_17_up(self):
         self.view_class.raise_exception = False
@@ -525,7 +525,7 @@ class TestSSLRequiredMixin(test.TestCase):
         self.assertEqual('https', resp.request.get('wsgi.url_scheme'))
 
     @pytest.mark.skipif(
-        django.VERSION[:2] > (1, 6),
+        DJANGO_VERSION[:2] > (1, 6),
         reason='Django 1.7 and above have secure=True option, below does not')
     def test_https_does_not_redirect_django_16_down(self):
         self.view_class.raise_exception = False

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import mock
 import pytest
 
-import django
+from django import VERSION as DJANGO_VERSION
 from django.contrib import messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.messages.storage.base import Message
@@ -589,7 +589,7 @@ class MessageMixinTests(test.TestCase):
             self.get_request_response(TestView.as_view())
 
     @pytest.mark.skipif(
-        django.VERSION < (1, 5),
+        DJANGO_VERSION < (1, 5),
         reason='Some features of MessageMixin are only available in '
                'Django >= 1.5')
     def test_wrapper_available_in_dispatch(self):
@@ -618,7 +618,7 @@ class MessageMixinTests(test.TestCase):
         # This test is designed to break when django.contrib.messages.api
         # changes (items being added or removed).
         excluded_API = set()
-        if django.VERSION >= (1, 7):
+        if DJANGO_VERSION >= (1, 7):
             excluded_API.add('MessageFailure')
         self.assertEqual(
             _MessageAPIWrapper.API | excluded_API,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -103,6 +103,9 @@ urlpatterns = patterns(
     url(r'all_verbs/$', views.AllVerbsView.as_view()),
     url(r'all_verbs_no_handler/$',
         views.AllVerbsView.as_view(all_handler=None)),
+
+    # SSLRequiredMixin tests
+    url(r'^sslrequired/$', views.SSLRequiredView.as_view()),
 )
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -192,7 +192,8 @@ class ArticleListViewWithCustomQueryset(views.SelectRelatedMixin, ListView):
     """
     Another list view for articles, required to test SelectRelatedMixin.
     """
-    queryset = Article.objects.select_related('author').prefetch_related('article_set')
+    queryset = Article.objects.select_related('author').prefetch_related(
+        'article_set')
     template_name = 'blank.html'
     select_related = ()
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -334,3 +334,7 @@ class UserPassesTestNotImplementedView(views.UserPassesTestMixin, OkView):
 class AllVerbsView(views.AllVerbsMixin, View):
     def all(self, request, *args, **kwargs):
         return HttpResponse('All verbs return this!')
+
+
+class SSLRequiredView(views.SSLRequiredMixin, OkView):
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py26-django{14,15,16},
-          py27-django14,
+envlist = py26-django{15,16},
           py{27,33,34}-django{15,16,17,18}
 install_command = pip install {opts} {packages}
 
@@ -22,9 +21,7 @@ deps =
     factory_boy
     coverage
     argparse
-    django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
-


### PR DESCRIPTION
![YES](http://www.reactiongifs.com/r/kfp.gif)

## SSLRequiredMixin

Addresses #108 

* New `SSLRequiredMixin`.
    * Redirects `http` -> `https`
    * Optionally, set `view.raise_exception = True` to raise a `404` instead of redirecting.
    * If `DEBUG=True` the SSL mixin is bypassed.
* 100% test coverage.
* Added Docs.
    * Updated the docs theme from `default` to `alabaster`
* Drop support for Django 1.4. Updated tox.
* Importing Django.VERSION instead of the whole of Django for version checking in tests.