### PR TITLE
add in simple example for overriding the get_group_required method.

### DIFF
--- a/docs/access.rst
+++ b/docs/access.rst
@@ -179,6 +179,22 @@ Custom Group Usage
                 return False
 
 
+Dynamically Build Groups
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    from django.views import TemplateView
+
+    from braces.views import GroupRequiredMixin
+
+
+    class SomeProtectedView(GroupRequiredMixin, TemplateView):
+        def get_group_required(self):
+            # Get group or groups however you wish
+            group = 'secret_group'
+            return group
+
 .. _UserPassesTestMixin:
 
 UserPassesTestMixin


### PR DESCRIPTION
addresses #157 

Added a simple example for overriding `GroupRequiredMixin.get_group_required()` .