### PR TITLE
Fix/jsonresponsemixin docs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+* :support:`-` Fix small issue in docs for JsonResponseMixin. The accepted kwarg for the render_to_response method is status not status_code.
 * :release:`1.8.0 <2015-04-16>`
 * :support:`145` Allow custom exceptions to be raised by all AccessMixins.
 * :feature:`171` New :ref:`SSLRequiredMixin`. Redirect http -> https.

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -151,7 +151,7 @@ JSONResponseMixin
 -----------------
 
 .. versionchanged:: 1.1
-    ``render_json_response`` now accepts a ``status_code`` keyword argument.
+    ``render_json_response`` now accepts a ``status`` keyword argument.
     ``json_dumps_kwargs`` class-attribute and ``get_json_dumps_kwargs`` method to provide arguments to the ``json.dumps()`` method.
 
 A simple mixin to handle very simple serialization as a response to the browser.


### PR DESCRIPTION
## Documentation Fix

closes #175 

* `JsonResponseMixin.render_json_response` method accepts the kwarg `status`, not `status_code`.
* Added the fix to the changelog.