### PR TITLE
Removed u prefixes from strings

### DIFF
--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import six
 
 from django.core import serializers
@@ -29,12 +30,12 @@ class JSONResponseMixin(object):
                 '{0} is missing a content type. Define {0}.content_type, '
                 'or override {0}.get_content_type().'.format(
                     self.__class__.__name__))
-        return self.content_type or u"application/json"
+        return self.content_type or "application/json"
 
     def get_json_dumps_kwargs(self):
         if self.json_dumps_kwargs is None:
             self.json_dumps_kwargs = {}
-        self.json_dumps_kwargs.setdefault(u'ensure_ascii', False)
+        self.json_dumps_kwargs.setdefault('ensure_ascii', False)
         return self.json_dumps_kwargs
 
     def render_json_response(self, context_dict, status=200):
@@ -45,7 +46,7 @@ class JSONResponseMixin(object):
         json_context = json.dumps(
             context_dict,
             cls=self.json_encoder_class,
-            **self.get_json_dumps_kwargs()).encode(u'utf-8')
+            **self.get_json_dumps_kwargs()).encode('utf-8')
         return HttpResponse(json_context,
                             content_type=self.get_content_type(),
                             status=status)
@@ -55,7 +56,7 @@ class JSONResponseMixin(object):
         Serializes objects using Django's builtin JSON serializer. Additional
         kwargs can be used the same way for django.core.serializers.serialize.
         """
-        json_data = serializers.serialize(u"json", objects, **kwargs)
+        json_data = serializers.serialize("json", objects, **kwargs)
         return HttpResponse(json_data, content_type=self.get_content_type())
 
 
@@ -69,7 +70,7 @@ class AjaxResponseMixin(object):
         request_method = request.method.lower()
 
         if request.is_ajax() and request_method in self.http_method_names:
-            handler = getattr(self, u"{0}_ajax".format(request_method),
+            handler = getattr(self, "{0}_ajax".format(request_method),
                               self.http_method_not_allowed)
             self.request = request
             self.args = args
@@ -112,7 +113,7 @@ class JsonRequestResponseMixin(JSONResponseMixin):
                     {'message': 'Thanks!'})
     """
     require_json = False
-    error_response_dict = {u"errors": [u"Improperly formatted request"]}
+    error_response_dict = {"errors": ["Improperly formatted request"]}
 
     def render_bad_request_response(self, error_dict=None):
         if error_dict is None:
@@ -121,13 +122,13 @@ class JsonRequestResponseMixin(JSONResponseMixin):
             error_dict,
             cls=self.json_encoder_class,
             **self.get_json_dumps_kwargs()
-        ).encode(u'utf-8')
+        ).encode('utf-8')
         return HttpResponseBadRequest(
             json_context, content_type=self.get_content_type())
 
     def get_request_json(self):
         try:
-            return json.loads(self.request.body.decode(u'utf-8'))
+            return json.loads(self.request.body.decode('utf-8'))
         except ValueError:
             return None
 


### PR DESCRIPTION
This seems to restore Python 3.2 compatibility.

I tried to run the test suite but I'm getting a traceback I can't make sense of:
```
$ py.test tests/
Traceback (most recent call last):
  File "/path/to/venv/bin/py.test", line 9, in <module>
    load_entry_point('pytest==2.7.2', 'console_scripts', 'py.test')()
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/config.py", line 32, in main
    config = _prepareconfig(args, plugins)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/config.py", line 85, in _prepareconfig
    pluginmanager=pluginmanager, args=args)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 521, in __call__
    return self._docall(self.methods, kwargs)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 528, in _docall
    firstresult=self.firstresult).execute()
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 393, in execute
    return wrapped_call(method(*args), self.execute)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 109, in wrapped_call
    wrap_controller.send(call_outcome)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/helpconfig.py", line 28, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 137, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 123, in __init__
    self.result = func()
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 394, in execute
    res = method(*args)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/config.py", line 636, in pytest_cmdline_parse
    self.parse(args)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/config.py", line 746, in parse
    self._preparse(args)
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/config.py", line 713, in _preparse
    self.pluginmanager.consider_setuptools_entrypoints()
  File "/path/to/venv/lib/python3.2/site-packages/_pytest/core.py", line 278, in consider_setuptools_entrypoints
    plugin = ep.load()
  File "/path/to/venv/lib/python3.2/site-packages/distribute-0.6.24-py3.2.egg/pkg_resources.py", line 1989, in load
    if require: self.require(env, installer)
  File "/path/to/venv/lib/python3.2/site-packages/distribute-0.6.24-py3.2.egg/pkg_resources.py", line 2002, in require
    working_set.resolve(self.dist.requires(self.extras),env,installer)))
  File "/path/to/venv/lib/python3.2/site-packages/distribute-0.6.24-py3.2.egg/pkg_resources.py", line 588, in resolve
    raise VersionConflict(dist,req) # XXX put more info here
pkg_resources.VersionConflict: (coverage 4.0a6 (/path/to/venv/lib/python3.2/site-packages), Requirement.parse('coverage>=3.7.1,<4.0a1'))
```