### PR TITLE
Python 3.2 Support

### DIFF
--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import six
 
 from django.core import serializers
@@ -29,12 +30,12 @@ class JSONResponseMixin(object):
                 '{0} is missing a content type. Define {0}.content_type, '
                 'or override {0}.get_content_type().'.format(
                     self.__class__.__name__))
-        return self.content_type or u"application/json"
+        return self.content_type or "application/json"
 
     def get_json_dumps_kwargs(self):
         if self.json_dumps_kwargs is None:
             self.json_dumps_kwargs = {}
-        self.json_dumps_kwargs.setdefault(u'ensure_ascii', False)
+        self.json_dumps_kwargs.setdefault('ensure_ascii', False)
         return self.json_dumps_kwargs
 
     def render_json_response(self, context_dict, status=200):
@@ -45,7 +46,7 @@ class JSONResponseMixin(object):
         json_context = json.dumps(
             context_dict,
             cls=self.json_encoder_class,
-            **self.get_json_dumps_kwargs()).encode(u'utf-8')
+            **self.get_json_dumps_kwargs()).encode('utf-8')
         return HttpResponse(json_context,
                             content_type=self.get_content_type(),
                             status=status)
@@ -55,7 +56,7 @@ class JSONResponseMixin(object):
         Serializes objects using Django's builtin JSON serializer. Additional
         kwargs can be used the same way for django.core.serializers.serialize.
         """
-        json_data = serializers.serialize(u"json", objects, **kwargs)
+        json_data = serializers.serialize("json", objects, **kwargs)
         return HttpResponse(json_data, content_type=self.get_content_type())
 
 
@@ -69,7 +70,7 @@ class AjaxResponseMixin(object):
         request_method = request.method.lower()
 
         if request.is_ajax() and request_method in self.http_method_names:
-            handler = getattr(self, u"{0}_ajax".format(request_method),
+            handler = getattr(self, "{0}_ajax".format(request_method),
                               self.http_method_not_allowed)
             self.request = request
             self.args = args
@@ -112,7 +113,7 @@ class JsonRequestResponseMixin(JSONResponseMixin):
                     {'message': 'Thanks!'})
     """
     require_json = False
-    error_response_dict = {u"errors": [u"Improperly formatted request"]}
+    error_response_dict = {"errors": ["Improperly formatted request"]}
 
     def render_bad_request_response(self, error_dict=None):
         if error_dict is None:
@@ -121,13 +122,13 @@ class JsonRequestResponseMixin(JSONResponseMixin):
             error_dict,
             cls=self.json_encoder_class,
             **self.get_json_dumps_kwargs()
-        ).encode(u'utf-8')
+        ).encode('utf-8')
         return HttpResponseBadRequest(
             json_context, content_type=self.get_content_type())
 
     def get_request_json(self):
         try:
-            return json.loads(self.request.body.decode(u'utf-8'))
+            return json.loads(self.request.body.decode('utf-8'))
         except ValueError:
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Framework :: Django",

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import pytest
 import datetime
@@ -57,7 +57,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         self.client.login(username=user.username, password='asdf1234')
         resp = self.client.get(self.view_url)
-        self.assertRedirects(resp, u'/accounts/login/?next={0}'.format(
+        self.assertRedirects(resp, '/accounts/login/?next={0}'.format(
             self.view_url))
 
     def test_raise_permission_denied(self):
@@ -148,12 +148,12 @@ class _TestAccessBasicsMixin(TestViewHelper):
         req = self.build_request(user=user, path=self.view_url)
         resp = self.dispatch_view(req, login_url='/login/')
         self.assertEqual(
-            u'/login/?next={0}'.format(self.view_url),
+            '/login/?next={0}'.format(self.view_url),
             resp['Location'])
 
         # Test with reverse_lazy
         resp = self.dispatch_view(req, login_url=reverse_lazy('headline'))
-        self.assertEqual(u'/headline/?next={0}'.format(
+        self.assertEqual('/headline/?next={0}'.format(
             self.view_url), resp['Location'])
 
     def test_custom_redirect_field_name(self):
@@ -163,7 +163,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         req = self.build_request(user=user, path=self.view_url)
         resp = self.dispatch_view(req, redirect_field_name='foo')
-        expected_url = u'/accounts/login/?foo={0}'.format(self.view_url)
+        expected_url = '/accounts/login/?foo={0}'.format(self.view_url)
         self.assertEqual(expected_url, resp['Location'])
 
     @override_settings(LOGIN_URL=None)
@@ -195,7 +195,7 @@ class _TestAccessBasicsMixin(TestViewHelper):
         user = self.build_unauthorized_user()
         self.client.login(username=user.username, password='asdf1234')
         resp = self.client.get(self.view_url)
-        self.assertRedirects(resp, u'/auth/login/?next={0}'.format(
+        self.assertRedirects(resp, '/auth/login/?next={0}'.format(
             self.view_url))
 
     def test_redirect_unauthenticated(self):
@@ -350,7 +350,7 @@ class TestMultiplePermissionsRequiredMixin(
             user = UserFactory(permissions=permissions)
             self.client.login(username=user.username, password='asdf1234')
             resp = self.client.get(url)
-            self.assertRedirects(resp, u'/accounts/login/?next={0}'.format(
+            self.assertRedirects(resp, '/accounts/login/?next={0}'.format(
                 url))
 
     def test_invalid_permissions(self):
@@ -508,14 +508,14 @@ class TestGroupRequiredMixin(_TestAccessBasicsMixin, test.TestCase):
             view.get_group_required()
 
     def test_with_unicode(self):
-        self.view_class.group_required = u'niño'
-        self.assertEqual(u'niño', self.view_class.group_required)
+        self.view_class.group_required = 'niño'
+        self.assertEqual('niño', self.view_class.group_required)
 
         user = self.build_authorized_user()
         group = user.groups.all()[0]
-        group.name = u'niño'
+        group.name = 'niño'
         group.save()
-        self.assertEqual(u'niño', user.groups.all()[0].name)
+        self.assertEqual('niño', user.groups.all()[0].name)
 
         self.client.login(username=user.username, password='asdf1234')
         resp = self.client.get(self.view_url)

--- a/tests/test_ajax_mixins.py
+++ b/tests/test_ajax_mixins.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import mock
 
@@ -20,7 +20,7 @@ class TestAjaxResponseMixin(TestViewHelper, test.TestCase):
     """
     Tests for AjaxResponseMixin.
     """
-    methods = [u'get', u'post', u'put', u'delete']
+    methods = ['get', 'post', 'put', 'delete']
 
     def test_xhr(self):
         """
@@ -29,9 +29,8 @@ class TestAjaxResponseMixin(TestViewHelper, test.TestCase):
         # AjaxResponseView returns 'AJAX_OK' when requested with XmlHttpRequest
         for m in self.methods:
             fn = getattr(self.client, m)
-            resp = fn(u'/ajax_response/',
-                      HTTP_X_REQUESTED_WITH=u'XMLHttpRequest')
-            assert force_text(resp.content) == u'AJAX_OK'
+            resp = fn('/ajax_response/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+            assert force_text(resp.content) == 'AJAX_OK'
 
     def test_not_xhr(self):
         """
@@ -40,18 +39,18 @@ class TestAjaxResponseMixin(TestViewHelper, test.TestCase):
         """
         for m in self.methods:
             fn = getattr(self.client, m)
-            resp = fn(u'/ajax_response/')
-            assert force_text(resp.content) == u'OK'
+            resp = fn('/ajax_response/')
+            assert force_text(resp.content) == 'OK'
 
     def test_fallback_to_normal_methods(self):
         """
         Ajax methods should fallback to normal methods by default.
         """
         test_cases = [
-            (u'get', u'get'),
-            (u'post', u'post'),
-            (u'put', u'get'),
-            (u'delete', u'get'),
+            ('get', 'get'),
+            ('post', 'post'),
+            ('put', 'get'),
+            ('delete', 'get'),
         ]
 
         for ajax_method, fallback in test_cases:
@@ -59,7 +58,7 @@ class TestAjaxResponseMixin(TestViewHelper, test.TestCase):
             m.return_value = HttpResponse()
             req = self.build_request()
             setattr(mixin, fallback, m)
-            fn = getattr(mixin, u"{0}_ajax".format(ajax_method))
+            fn = getattr(mixin, "{0}_ajax".format(ajax_method))
             ret = fn(req, 1, 2, meth=ajax_method)
             # check if appropriate method has been called
             m.assert_called_once_with(req, 1, 2, meth=ajax_method)
@@ -75,8 +74,8 @@ class TestJSONResponseMixin(TestViewHelper, test.TestCase):
 
     def assert_json_response(self, resp, status_code=200):
         self.assertEqual(status_code, resp.status_code)
-        self.assertEqual(u'application/json',
-                         resp[u'content-type'].split(u';')[0])
+        self.assertEqual('application/json',
+                         resp['content-type'].split(';')[0])
 
     def get_content(self, url):
         """
@@ -92,9 +91,9 @@ class TestJSONResponseMixin(TestViewHelper, test.TestCase):
         Tests render_json_response() method.
         """
         user = UserFactory()
-        self.client.login(username=user.username, password=u'asdf1234')
-        data = json.loads(self.get_content(u'/simple_json/'))
-        self.assertEqual({u'username': user.username}, data)
+        self.client.login(username=user.username, password='asdf1234')
+        data = json.loads(self.get_content('/simple_json/'))
+        self.assertEqual({'username': user.username}, data)
 
     def test_serialization(self):
         """
@@ -102,14 +101,14 @@ class TestJSONResponseMixin(TestViewHelper, test.TestCase):
         using django's serializer framework.
         """
         a1, a2 = [ArticleFactory() for __ in range(2)]
-        data = json.loads(self.get_content(u'/article_list_json/'))
+        data = json.loads(self.get_content('/article_list_json/'))
         self.assertIsInstance(data, list)
         self.assertEqual(2, len(data))
         titles = []
         for row in data:
             # only title has been serialized
-            self.assertEqual(1, len(row[u'fields']))
-            titles.append(row[u'fields'][u'title'])
+            self.assertEqual(1, len(row['fields']))
+            titles.append(row['fields']['title'])
 
         self.assertIn(a1.title, titles)
         self.assertIn(a2.title, titles)
@@ -128,12 +127,12 @@ class TestJSONResponseMixin(TestViewHelper, test.TestCase):
         is longer than the normal one.
         """
         user = UserFactory()
-        self.client.login(username=user.username, password=u'asfa')
-        normal_content = self.get_content(u'/simple_json/')
-        self.view_class.json_dumps_kwargs = {u'indent': 2}
-        pretty_content = self.get_content(u'/simple_json/')
-        normal_json = json.loads(u'{0}'.format(normal_content))
-        pretty_json = json.loads(u'{0}'.format(pretty_content))
+        self.client.login(username=user.username, password='asfa')
+        normal_content = self.get_content('/simple_json/')
+        self.view_class.json_dumps_kwargs = {'indent': 2}
+        pretty_content = self.get_content('/simple_json/')
+        normal_json = json.loads('{0}'.format(normal_content))
+        pretty_json = json.loads('{0}'.format(pretty_content))
         self.assertEqual(normal_json, pretty_json)
         self.assertTrue(len(pretty_content) > len(normal_content))
 
@@ -141,25 +140,25 @@ class TestJSONResponseMixin(TestViewHelper, test.TestCase):
         """
         Tests setting custom `json_encoder_class` attribute.
         """
-        data = json.loads(self.get_content(u'/simple_json_custom_encoder/'))
-        self.assertEqual({u'numbers': [1, 2, 3]}, data)
+        data = json.loads(self.get_content('/simple_json_custom_encoder/'))
+        self.assertEqual({'numbers': [1, 2, 3]}, data)
 
 
 class TestJsonRequestResponseMixin(TestViewHelper, test.TestCase):
     view_class = JsonRequestResponseView
-    request_dict = {u'status': u'operational'}
+    request_dict = {'status': 'operational'}
 
     def test_get_request_json_properly_formatted(self):
         """
         Properly formatted JSON requests should result in a JSON object
         """
-        data = json.dumps(self.request_dict).encode(u'utf-8')
+        data = json.dumps(self.request_dict).encode('utf-8')
         response = self.client.post(
-            u'/json_request/',
-            content_type=u'application/json',
+            '/json_request/',
+            content_type='application/json',
             data=data
         )
-        response_json = json.loads(response.content.decode(u'utf-8'))
+        response_json = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_json, self.request_dict)
 
@@ -168,10 +167,10 @@ class TestJsonRequestResponseMixin(TestViewHelper, test.TestCase):
         Improperly formatted JSON requests should make request_json == None
         """
         response = self.client.post(
-            u'/json_request/',
+            '/json_request/',
             data=self.request_dict
         )
-        response_json = json.loads(response.content.decode(u'utf-8'))
+        response_json = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_json, None)
 
@@ -181,10 +180,10 @@ class TestJsonRequestResponseMixin(TestViewHelper, test.TestCase):
         or None, the client should get a 400 error
         """
         response = self.client.post(
-            u'/json_bad_request/',
+            '/json_bad_request/',
             data=self.request_dict
         )
-        response_json = json.loads(response.content.decode(u'utf-8'))
+        response_json = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response_json, self.view_class.error_response_dict)
 
@@ -194,9 +193,9 @@ class TestJsonRequestResponseMixin(TestViewHelper, test.TestCase):
         or None, the client should get a 400 error
         """
         response = self.client.post(
-            u'/json_custom_bad_request/',
+            '/json_custom_bad_request/',
             data=self.request_dict
         )
-        response_json = json.loads(response.content.decode(u'utf-8'))
+        response_json = json.loads(response.content.decode('utf-8'))
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response_json, {u'error': u'you messed up'})
+        self.assertEqual(response_json, {'error': 'you messed up'})

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import mock
 import pytest
@@ -667,8 +667,8 @@ class TestFormMessageMixins(test.TestCase):
 
     def test_form_valid_returns_message(self):
         mixin = FormValidMessageMixin()
-        mixin.form_valid_message = u'Good øø'
-        self.assertEqual(u'Good øø', mixin.get_form_valid_message())
+        mixin.form_valid_message = 'Good øø'
+        self.assertEqual('Good øø', mixin.get_form_valid_message())
 
     def test_form_invalid_message_not_set(self):
         mixin = FormInvalidMessageMixin()
@@ -683,8 +683,8 @@ class TestFormMessageMixins(test.TestCase):
 
     def test_form_invalid_returns_message(self):
         mixin = FormInvalidMessageMixin()
-        mixin.form_invalid_message = u'Bad øø'
-        self.assertEqual(u'Bad øø', mixin.get_form_invalid_message())
+        mixin.form_invalid_message = 'Bad øø'
+        self.assertEqual('Bad øø', mixin.get_form_invalid_message())
 
 
 class TestAllVerbsMixin(test.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist = py26-django{15,16},
-          py{27,33,34}-django{15,16,17,18}
+          py{27,32,33,34}-django{15,16,17,18}
 install_command = pip install {opts} {packages}
 
 [testenv]
 basepython =
     py26: python2.6
     py27: python2.7
+    py32: python3.2
     py33: python3.3
     py34: python3.4
 


### PR DESCRIPTION
Removes the `u` prefix from strings and makes sure that tests run against Python 3.2.