### PR TITLE
Feature: EnsureCsrfCookieMixin

### DIFF
--- a/braces/views/__init__.py
+++ b/braces/views/__init__.py
@@ -20,6 +20,7 @@ from ._ajax import (
 )
 from ._forms import (
     CsrfExemptMixin,
+    EnsureCsrfCookieMixin,
     FormInvalidMessageMixin,
     FormMessagesMixin,
     FormValidMessageMixin,

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.functional import curry, Promise
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 
 
 class CsrfExemptMixin(object):
@@ -20,6 +20,18 @@ class CsrfExemptMixin(object):
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
         return super(CsrfExemptMixin, self).dispatch(*args, **kwargs)
+
+
+class EnsureCsrfCookieMixin(object):
+    """
+    Ensures that the CSRF cookie will be set.
+    NOTE:
+        This should be the left-most mixin of a view.
+    """
+
+    @method_decorator(ensure_csrf_cookie)
+    def dispatch(self, *args, **kwargs):
+        return super(EnsureCsrfCookieMixin, self).dispatch(*args, **kwargs)
 
 
 class UserFormKwargsMixin(object):

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -148,6 +148,15 @@ class TestCsrfExemptMixin(test.TestCase):
         self.assertEqual("OK", force_text(resp.content))
 
 
+class TestEnsureCsrfCookieMixin(test.TestCase):
+    """
+    Tests for EnsureCsrfCookieMixin.
+    """
+    def test_csrf_cookie_is_set(self):
+        resp = self.client.get('/ensure_csrf_cookie/')
+        self.assertEqual(True, 'csrftoken' in resp.cookies)
+
+
 class TestSelectRelatedMixin(TestViewHelper, test.TestCase):
     view_class = ArticleListView
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -83,6 +83,9 @@ urlpatterns = patterns(
     # CsrfExemptMixin tests
     url(r'^csrf_exempt/$', views.CsrfExemptView.as_view()),
 
+    # EnsureCsrfCookieMixin tests
+    url(r'^ensure_csrf_cookie/$', views.EnsureCsrfCookieView.as_view()),
+
     # JSONResponseMixin tests
     url(r'^simple_json/$', views.SimpleJsonView.as_view()),
     url(r'^simple_json_custom_encoder/$',

--- a/tests/views.py
+++ b/tests/views.py
@@ -268,6 +268,10 @@ class CsrfExemptView(views.CsrfExemptMixin, OkView):
     pass
 
 
+class EnsureCsrfCookieView(views.EnsureCsrfCookieMixin, OkView):
+    pass
+
+
 class AuthorDetailView(views.PrefetchRelatedMixin, ListView):
     model = User
     prefetch_related = ['article_set']


### PR DESCRIPTION
I did this mixin for myself and then decided to contribute it to django-braces too, since it's already full of awesome mixins.

It is 100% same as a `CsrfExemptMixin` - it just uses `method_decorator` with a built-in Django decorator ([`@ensure_csrf_cookie`](https://docs.djangoproject.com/en/1.8/ref/csrf/#django.views.decorators.csrf.ensure_csrf_cookie)) over a `View.dispatch()` method.

Covered with a test (a really simple one). It passes on my local environment (Python 2.7.10, Django 1.8.3).

I have also wrote a second test checking for _not_ having a `csrftoken` cookie in the response if the mixin wasn't used in a view, but I decided not to commit it because I think a second view for that kind of test is a bit overkill; nor did I want to re-use some of the other mixins' test views.
Let me know if you nevertheless need a test for that, I'll add it.
