### PR TITLE
Use Django's bundled six; avoids additional external dependency.

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -1,7 +1,6 @@
 import inspect
 import datetime
 import re
-import six
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -10,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
                          Http404, HttpResponse)
 from django.shortcuts import resolve_url
+from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
-import six
 
 from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils import six
 
 ## Django 1.5+ compat
 try:

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -1,8 +1,7 @@
-import six
-
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
+from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.functional import curry, Promise

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ factory_boy
 mock
 pytest-django
 pytest-cov
-six
 coverage

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     license="BSD",
     packages=["braces"],
     zip_safe=False,
-    install_requires=["six"],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
As Django is always required for django-braces, use Django's bundled
six library for Python2/3 compatibility. Avoids an external dependency
that already exists.

See <https://docs.djangoproject.com/en/dev/topics/python3/>