### PR TITLE
Fix combining LoginRequired with other access mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.coverage.xml
 /htmlcov
 /.tox
+/.cache
 dist/
 .idea
 build/

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -28,6 +28,7 @@ Direct Contributors
 * Rag Sagar.V
 * Lacey Williams Henschel 
 * Gregory Shikhman
+* Mike Bryant
 
 Other Contributors
 ==================

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -27,6 +27,7 @@ Direct Contributors
 * Ben Cardy
 * Rag Sagar.V
 * Lacey Williams Henschel 
+* Gregory Shikhman
 
 Other Contributors
 ==================

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -57,15 +57,19 @@ class AccessMixin(object):
         return self.redirect_field_name
 
     def handle_no_permission(self, request):
-        if self.raise_exception and not self.redirect_unauthenticated_users:
-            if (inspect.isclass(self.raise_exception)
-                    and issubclass(self.raise_exception, Exception)):
-                raise self.raise_exception
-            if callable(self.raise_exception):
-                ret = self.raise_exception(request)
-                if isinstance(ret, (HttpResponse, StreamingHttpResponse)):
-                    return ret
-            raise PermissionDenied
+        if self.raise_exception:
+            if (self.redirect_unauthenticated_users
+                    and not self.request.user.is_authenticated()):
+                return self.no_permissions_fail(request)
+            else:
+                if (inspect.isclass(self.raise_exception)
+                        and issubclass(self.raise_exception, Exception)):
+                    raise self.raise_exception
+                if callable(self.raise_exception):
+                    ret = self.raise_exception(request)
+                    if isinstance(ret, (HttpResponse, StreamingHttpResponse)):
+                        return ret
+                raise PermissionDenied
 
         return self.no_permissions_fail(request)
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -327,6 +327,13 @@ class UserPassesTestView(views.UserPassesTestMixin, OkView):
             and user.email.endswith('@mydomain.com')
 
 
+class UserPassesTestLoginRequiredView(views.LoginRequiredMixin,
+                                      views.UserPassesTestMixin, OkView):
+    def test_func(self, user):
+        return user.is_staff and not user.is_superuser \
+            and user.email.endswith('@mydomain.com')
+
+
 class UserPassesTestNotImplementedView(views.UserPassesTestMixin, OkView):
     pass
 


### PR DESCRIPTION
Make it possible to combine `LoginRequiredMixin` with other `AccessMixin`s. This allows views which will redirect to login if unauthenticated, but raise an error if the user is unauthenticated but isn't allowed.
This stops the redirect loop in #161.

I'm using the approach in #200, which avoids api changes.

The tests pass (at least the versions I have available to test):
```
  py27-django15: commands succeeded
  py27-django16: commands succeeded
  py27-django17: commands succeeded
  py27-django18: commands succeeded
ERROR:   py32-django15: InterpreterNotFound: python3.2
ERROR:   py32-django16: InterpreterNotFound: python3.2
ERROR:   py32-django17: InterpreterNotFound: python3.2
ERROR:   py32-django18: InterpreterNotFound: python3.2
ERROR:   py33-django15: InterpreterNotFound: python3.3
ERROR:   py33-django16: InterpreterNotFound: python3.3
ERROR:   py33-django17: InterpreterNotFound: python3.3
ERROR:   py33-django18: InterpreterNotFound: python3.3
  py34-django15: commands succeeded
  py34-django16: commands succeeded
  py34-django17: commands succeeded
  py34-django18: commands succeeded
```

I've verified the tests fail, when run against the previous version of `_access.py`

The changes comply with `pep8`

Fixes #161.
Fixes #181.
Closes #196.
Closes #200.