### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mixins for Django's class-based views.
 [![PyPI version](https://badge.fury.io/py/django-braces.png)](http://badge.fury.io/py/django-braces)
 
 ## Documentation
-[Read The Docs](http://django-braces.readthedocs.io/en/latest/index.html)
+[Read The Docs](https://django-braces.readthedocs.io/en/latest/index.html)
 
 ## Installation
 Install from PyPI with `pip`:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.