### PR TITLE
Add support for Python 3.7 and Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,18 @@ matrix:
         env: TOX_ENV=py36-django21
       - python: 3.6
         env: TOX_ENV=py36-djangomaster
+      - python: 3.7
+        env: TOX_ENV=py37-django20
+        dist: xenial
+        sudo: required
+      - python: 3.7
+        env: TOX_ENV=py37-django21
+        dist: xenial
+        sudo: required
+      - python: 3.7
+        env: TOX_ENV=py37-djangomaster
+        dist: xenial
+        sudo: required
 
 script: tox -e $TOX_ENV
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,18 @@ matrix:
         env: TOX_ENV=py35-django111
       - python: 3.5
         env: TOX_ENV=py35-django20
+      - python: 3.5
+        env: TOX_ENV=py35-django21
+      - python: 3.5
+        env: TOX_ENV=py35-djangomaster
       - python: 3.6
         env: TOX_ENV=py36-django111
       - python: 3.6
         env: TOX_ENV=py36-django20
+      - python: 3.6
+        env: TOX_ENV=py36-django21
+      - python: 3.6
+        env: TOX_ENV=py36-djangomaster
 
 script: tox -e $TOX_ENV
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -50,4 +50,6 @@ We try to keep the project at 100% test coverage but know this isn't something
 we can achieve forever. So long as your tests cover your contribution 80% or
 better, we're happy to try and bump up that last bit, or just accept the code.
 
-We currently test Braces against late (usually latest) versions of Python 2.7, 3.4, 3.5, and 3.6. We also test against the latest released version of Django from 1.11 to 2.0.
+We currently test Braces against late (usually latest) versions of Python 2.7,
+3.4, 3.5, and 3.6. We also test against the latest released version of
+Django from 1.11 to 2.1.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0"
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1"
     ],
 )

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import warnings
+
 import mock
 import pytest
 
@@ -192,9 +194,16 @@ class TestSelectRelatedMixin(TestViewHelper, test.TestCase):
         qs.select_related = m
         m.reset_mock()
 
-        resp = self.dispatch_view(
-            self.build_request(),
-            view_class=ArticleListViewWithCustomQueryset)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            resp = self.dispatch_view(
+                self.build_request(),
+                view_class=ArticleListViewWithCustomQueryset)
+            assert len(w) == 1
+            warning = w[0]
+            assert issubclass(warning.category, UserWarning)
+            assert "The select_related attribute is empty" in str(warning.message)
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual(0, m.call_count)
 
@@ -244,9 +253,16 @@ class TestPrefetchRelatedMixin(TestViewHelper, test.TestCase):
         qs.prefetch_related = m
         m.reset_mock()
 
-        resp = self.dispatch_view(
-            self.build_request(),
-            view_class=ArticleListViewWithCustomQueryset)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            resp = self.dispatch_view(
+                self.build_request(),
+                view_class=ArticleListViewWithCustomQueryset)
+            assert len(w) == 1
+            warning = w[0]
+            assert issubclass(warning.category, UserWarning)
+            assert "The select_related attribute is empty" in str(warning.message)
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual(0, m.call_count)
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.exceptions import ImproperlyConfigured
-from django.contrib.auth.views import login
+from django.contrib.auth.views import LoginView
 from . import views
 from .compat import include, url, patterns_compat
 
@@ -116,8 +116,8 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    url(r'^accounts/login/$', login, {'template_name': 'blank.html'}),
-    url(r'^auth/login/$', login, {'template_name': 'blank.html'}),
+    url(r'^accounts/login/$', LoginView.as_view(template_name='blank.html')),
+    url(r'^auth/login/$', LoginView.as_view(template_name='blank.html')),
 ]
 try:
     urlpatterns += [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py{27}-django{111},py{34,35,36}-django{111,20}
+envlist =
+    py{27}-django{111},
+    py{34,35,36}-django{111,20},
+    py{35,36}-django{21,master}
 install_command = pip install {opts} "{packages}"
 
 [testenv]
@@ -22,3 +25,5 @@ deps =
     argparse
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    djangomaster: https://github.com/django/django/archive/master.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     py{27}-django{111},
-    py{34,35,36}-django{111,20},
-    py{35,36}-django{21,master}
+    py{34}-django{111,20},
+    py{35,36}-django{111,20,21,master},
+    py{37}-django{20,21,master}
 install_command = pip install {opts} "{packages}"
 
 [testenv]
@@ -11,6 +12,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 commands =
 	{posargs:py.test}
@@ -21,7 +23,9 @@ deps =
     py{27,34}: pytest==2.9.1
     py{27,34}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
+    py{37}: pytest-django>=3.4.0
     py{27,34,35,36}: coverage==4.1
+    py{37}: coverage>=4.5
     argparse
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1


### PR DESCRIPTION
- I had to adjust one minor issue with login views, but this only affected the tests.
- The tests expect the warning issued by `SelectRelatedMixin` now and test for it.  Before the warnings were printed which let me believe that the tests where outdated which was not the case.
- This also adds django master to the test matrix to capture incompatibilities as early as possible.

@kennethlove Can you push the missing tags (1.10+) to github?