### PR TITLE
Add CacheControlMixin and NeverCacheMixin

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -31,6 +31,7 @@ Direct Contributors
 * Mike Bryant
 * Fabio C. Barrionuevo da Luz
 * Sam Spencer
+* Ben Wilber
 
 Other Contributors
 ==================

--- a/braces/views/__init__.py
+++ b/braces/views/__init__.py
@@ -33,7 +33,9 @@ from ._other import (
     CanonicalSlugDetailMixin,
     SetHeadlineMixin,
     StaticContextMixin,
-    HeaderMixin
+    HeaderMixin,
+    CacheControlMixin,
+    NeverCacheMixin
 )
 from ._queries import (
     OrderableListMixin,

--- a/braces/views/_other.py
+++ b/braces/views/_other.py
@@ -204,5 +204,5 @@ class NeverCacheMixin(object):
     """
     @classmethod
     def as_view(cls, *args, **kwargs):
-        view_func = super().as_view(*args, **kwargs)
+        view_func = super(NeverCacheMixin, self).as_view(*args, **kwargs)
         return never_cache(view_func)

--- a/braces/views/_other.py
+++ b/braces/views/_other.py
@@ -204,5 +204,5 @@ class NeverCacheMixin(object):
     """
     @classmethod
     def as_view(cls, *args, **kwargs):
-        view_func = super(NeverCacheMixin, self).as_view(*args, **kwargs)
+        view_func = super(NeverCacheMixin, cls).as_view(*args, **kwargs)
         return never_cache(view_func)

--- a/braces/views/_other.py
+++ b/braces/views/_other.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
 from django.utils.encoding import force_text
+from django.views.decorators.cache import cache_control, never_cache
 try:
     from django.urls import resolve
 except ImportError:
@@ -150,3 +151,58 @@ class HeaderMixin(object):
             if key not in response:
                 response[key] = value
         return response
+
+
+class CacheControlMixin(object):
+    """
+    Mixin that allows setting Cache-Control options.
+
+    Specify Cache-Control options as class attributes on the view class.
+
+    Cache-Control directive explanations:
+    http://condor.depaul.edu/dmumaugh/readings/handouts/SE435/HTTP/node24.html
+
+    Django's ``django.views.decorators.cache.cache_control`` options:
+    https://docs.djangoproject.com/en/dev/topics/cache/#controlling-cache-using-other-headers
+    """
+    # These are all ``None``, which indicates unset.
+    cachecontrol_public = None
+    cachecontrol_private = None
+    cachecontrol_no_cache = None
+    cachecontrol_no_transform = None
+    cachecontrol_must_revalidate = None
+    cachecontrol_proxy_revalidate = None
+    cachecontrol_max_age = None
+    cachecontrol_s_maxage = None
+
+    @classmethod
+    def get_cachecontrol_options(cls):
+        opts = (
+            'public', 'private', 'no_cache', 'no_transform',
+            'must_revalidate', 'proxy_revalidate', 'max_age',
+            's_maxage')
+        options = {}
+        for opt in opts:
+            value = getattr(cls, 'cachecontrol_{}'.format(opt), None)
+            if value is not None:
+                options[opt] = value
+        return options
+
+    @classmethod
+    def as_view(cls, *args, **kwargs):
+        view_func = super(CacheControlMixin, cls).as_view(*args, **kwargs)
+        options = cls.get_cachecontrol_options()
+        if options:
+            return cache_control(**options)(view_func)
+        return view_func
+
+
+class NeverCacheMixin(object):
+    """
+    Mixin that applies Django's `never_cache` view decorator to prevent
+    upstream HTTP-based caching.
+    """
+    @classmethod
+    def as_view(cls, *args, **kwargs):
+        view_func = super().as_view(*args, **kwargs)
+        return never_cache(view_func)

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -646,3 +646,88 @@ If you need to set the headers dynamically, e.g depending on some request inform
             """
             for key, value in request.META.items():
                 yield "X-Request-{}".format(key), value
+
+
+
+.. _CacheControlMixin:
+
+CacheControlMixin
+-----------------------
+
+Mixin that allows setting ``Cache-Control`` header options.
+
+``Cache-Control`` directive explanations:
+
+http://condor.depaul.edu/dmumaugh/readings/handouts/SE435/HTTP/node24.html
+
+Django's ``django.views.decorators.cache.cache_control`` options:
+
+https://docs.djangoproject.com/en/dev/topics/cache/#controlling-cache-using-other-headers
+
+::
+
+    from django.views import TemplateView
+    from braces.views import CacheControlMixin
+
+
+    class MyView(CacheControlMixin, TemplateView):
+        template_name = "project/template.html"
+
+        # Specify Cache-Control options as class-level attributes.
+        # The arguments are passed to Django's `cache_control()` view decorator
+        # directly (with the `cachecontrol_` prefix removed.)
+        cachecontrol_public = True
+        cachecontrol_max_age = 60
+
+        # Alternatively, you can implement the ``get_cachecontrol_options()``
+        # classmethod that should return a dictionary of the kwargs passed to
+        # Django's `cache_control()` view decorator.
+        @classmethod
+        def get_cachecontrol_options(cls):
+            return {'public': True, 'max_age': 60}
+
+
+This will cause the following header to be emitted for every request to this view:
+
+::
+
+    Cache-Control: public, max-age=60
+
+
+Available ``Cache-Control`` options:
+
+::
+
+    # These are all `None` by default, which indicates unset.
+    cachecontrol_public = None
+    cachecontrol_private = None
+    cachecontrol_no_cache = None
+    cachecontrol_no_transform = None
+    cachecontrol_must_revalidate = None
+    cachecontrol_proxy_revalidate = None
+    cachecontrol_max_age = None
+    cachecontrol_s_maxage = None
+
+
+.. _NeverCacheMixin:
+
+NeverCacheMixin
+-----------------------
+
+Mixin that applies Django's ``django.views.decorators.cache.never_cache`` view decorator to prevent upstream HTTP-based caching.
+
+::
+
+    from django.views import TemplateView
+    from braces.views import NeverCacheMixin
+
+
+    class MyView(NeverCacheMixin, TemplateView):
+        template_name = "project/template.html"
+
+
+This will cause the following header to be emitted for every request to this view:
+
+::
+
+    Cache-Control: max-age=0, no-cache, no-store, must-revalidate

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -794,4 +794,4 @@ class TestNeverCacheMixin(test.TestCase):
     def test_nevercache(self):
         response = self.client.get('/nevercache/')
         options = [i.strip() for i in response['Cache-Control'].split(',')]
-        self.assertEqual(sorted(options), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store', ])
+        self.assertEqual(sorted(options), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store'])

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -785,11 +785,13 @@ class TestCacheControlMixin(test.TestCase):
 
     def test_cachecontrol_public(self):
         response = self.client.get('/cachecontrol/public/')
-        self.assertEqual(response['Cache-Control'], 'public, max-age=60')
+        options = [i.strip() for i in response['Cache-Control'].split(',')]
+        self.assertEqual(sorted(options), ['max-age=60', 'public'])
 
 
 class TestNeverCacheMixin(test.TestCase):
 
     def test_nevercache(self):
         response = self.client.get('/nevercache/')
-        self.assertEqual(response['Cache-Control'], 'max-age=0, no-cache, no-store, must-revalidate')
+        options = [i.strip() for i in response['Cache-Control'].split(',')]
+        self.assertEqual(sorted(options), ['max-age=0', 'must-revalidate', 'no-cache', 'no-store', ])

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -779,3 +779,17 @@ class TestHeaderMixin(test.TestCase):
     def test_existing(self):
         response = self.client.get('/headers/existing/')
         self.assertEqual(response['X-DJANGO-BRACES-EXISTING'], 'value')
+
+
+class TestCacheControlMixin(test.TestCase):
+
+    def test_cachecontrol_public(self):
+        response = self.client.get('/cachecontrol/public/')
+        self.assertEqual(response['Cache-Control'], 'public, max-age=60')
+
+
+class TestNeverCacheMixin(test.TestCase):
+
+    def test_nevercache(self):
+        response = self.client.get('/nevercache/')
+        self.assertEqual(response['Cache-Control'], 'max-age=0, no-cache, no-store, must-revalidate')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -113,6 +113,12 @@ urlpatterns = [
     url(r'^headers/attribute/$', views.AttributeHeaderView.as_view()),
     url(r'^headers/method/$', views.MethodHeaderView.as_view()),
     url(r'^headers/existing/$', views.ExistingHeaderView.as_view()),
+
+    # CacheControlMixin tests
+    url(r'^cachecontrol/public/$', views.CacheControlPublicView.as_view()),
+
+    # NeverCacheMixin tests
+    url(r'^nevercache/$', views.NeverCacheView.as_view()),
 ]
 
 urlpatterns += [

--- a/tests/views.py
+++ b/tests/views.py
@@ -381,3 +381,14 @@ class ExistingHeaderView(views.HeaderMixin, AuxiliaryHeaderView):
     headers = {
         'X-DJANGO-BRACES-EXISTING': 'other value'
     }
+
+
+class CacheControlPublicView(views.CacheControlMixin, OkView):
+    cachecontrol_public = True
+    cachecontrol_max_age = 60
+
+
+class NeverCacheView(views.NeverCacheMixin, OkView):
+    """
+    View that will never be cached upstream.
+    """


### PR DESCRIPTION
Hello,

I've been using a couple of my own caching-related mixins in various projects for a few years and thought they would be useful to add to this project.  I've implemented `CacheControlMixin` and `NeverCacheMixin` which are basically just thin shortcuts to Django's own `cache_control()` and `never_cache()` view decorators.

Example usage of the `CacheControlMixin`

```
from django.views import TemplateView
from braces.views import CacheControlMixin


class MyView(CacheControlMixin, TemplateView):
    template_name = "project/template.html"

    # Specify Cache-Control options as class-level attributes.
    # The arguments are passed to Django's `cache_control()` view decorator
    # directly (with the `cachecontrol_` prefix removed.)
    cachecontrol_public = True
    cachecontrol_max_age = 60

    # Alternatively, you can implement the `get_cachecontrol_options()`
    # classmethod that should return a dictionary of the kwargs passed to
    # Django's `cache_control()` view decorator.
    @classmethod
    def get_cachecontrol_options(cls):
        return {'public': True, 'max_age': 60}
```

This will cause the following header to be emitted for every request to this view:
```
Cache-Control: public, max-age=60
```

Similarly, `NeverCacheMixin` prevents upstream HTTP-based caching:

```
from django.views import TemplateView
from braces.views import NeverCacheMixin


class MyView(NeverCacheMixin, TemplateView):
    template_name = "project/template.html"
```

This will cause the following header to be emitted for every request to this view:

```
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
```

I've included tests and updated docs.  Let me know if this is useful or if there are any changes that you would like made.

Thanks!
Ben
