### PR TITLE
Docs: update (broken) Django docs links

### DIFF
--- a/docs/form.rst
+++ b/docs/form.rst
@@ -248,6 +248,6 @@ Static & Dynamic Example
 
 
 .. _CRUD: http://en.wikipedia.org/wiki/Create,_read,_update_and_delete
-.. _CSRF protection: https://docs.djangoproject.com/en/1.5/ref/contrib/csrf/
-.. _csrf_exempt: https://docs.djangoproject.com/en/1.5/ref/contrib/csrf/#django.views.decorators.csrf.csrf_exempt
-.. _messages: https://docs.djangoproject.com/en/1.7/ref/contrib/messages/
+.. _CSRF protection: https://docs.djangoproject.com/en/stable/ref/csrf/
+.. _csrf_exempt: https://docs.djangoproject.com/en/stable/ref/csrf/#django.views.decorators.csrf.csrf_exempt
+.. _messages: https://docs.djangoproject.com/en/stable/ref/contrib/messages/


### PR DESCRIPTION
At least the CSRF docs were pointing at 1.5 which is old and no longer available on docs.djangoproject.com