### PR TITLE
MANIFEST.in: Add form.html and other testing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,6 @@ include CONTRIBUTORS.txt
 recursive-include braces *.py
 recursive-include docs *.rst
 recursive-include tests *.py
+recursive-include tests/templates *.html
+include conftest.py tox.ini requirements.txt
 prune docs/_build


### PR DESCRIPTION
Tests from sdist fail due to missing form.html

Also add other files useful for running tests from the sdist.

Fixes https://github.com/brack3t/django-braces/issues/248