### PR TITLE
Include documentation Makefile and conf.py in source tarballs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md
 include LICENSE
 include CONTRIBUTORS.txt
 recursive-include braces *.py
-recursive-include docs *.rst
+recursive-include docs Makefile conf.py *.rst
 recursive-include tests *.py
 recursive-include tests/templates *.html
 include conftest.py tox.ini requirements.txt


### PR DESCRIPTION
It is not possible to build the documentation without at least the conf.py file.