### PR TITLE
using six replace django six && custom curry when python2.x

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -2,6 +2,7 @@ import inspect
 import datetime
 import re
 
+import six
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login, logout_then_login
@@ -9,7 +10,6 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
                          Http404, HttpResponse, StreamingHttpResponse)
 from django.shortcuts import resolve_url
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
 import json
+
+import six
 from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.utils import six
 
 
 class JSONResponseMixin(object):

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -1,9 +1,17 @@
+try:
+    from functools import partialmethod as curry
+except ImportError:
+    def curry(_curried_func, *args, **kwargs):
+        def _curried(*moreargs, **morekwargs):
+            return _curried_func(*(args + moreargs), **dict(kwargs, **morekwargs))
+        return _curried
+
+import six
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
-from django.utils.functional import curry, Promise
+from django.utils.functional import Promise
 from django.views.decorators.csrf import csrf_exempt
 try:
     from django.urls import reverse

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     packages=["braces"],
     zip_safe=False,
     include_package_data=True,
+    install_requires=["six==1.12.0"],
     classifiers=[
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
ref: https://docs.djangoproject.com/en/dev/releases/3.0/#removed-private-python-2-compatibility-apis