### PR TITLE
Remove unused imports

### DIFF
--- a/braces/views/__init__.py
+++ b/braces/views/__init__.py
@@ -25,8 +25,7 @@ from ._forms import (
     FormValidMessageMixin,
     MessageMixin,
     SuccessURLRedirectListMixin,
-    UserFormKwargsMixin,
-    _MessageAPIWrapper
+    UserFormKwargsMixin
 )
 from ._other import (
     AllVerbsMixin,

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 import datetime
 
 from django import test

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import mock
-import pytest
 
 from django.contrib import messages
 from django.contrib.messages.middleware import MessageMiddleware
@@ -13,7 +12,7 @@ from django import test
 from django.test.utils import override_settings
 from django.views.generic import View
 
-from braces.views import (SetHeadlineMixin, MessageMixin, _MessageAPIWrapper,
+from braces.views import (SetHeadlineMixin, MessageMixin,
                           FormValidMessageMixin, FormInvalidMessageMixin)
 from .compat import force_text
 from .factories import UserFactory


### PR DESCRIPTION
This PR removes unused imports of `pytest` and `braces.views._forms._MessageAPIWrapper` from the codebase.