### PR TITLE
django 3.0 compatibility

### DIFF
--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
                          Http404, HttpResponse, StreamingHttpResponse)
 from django.shortcuts import resolve_url
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 
@@ -311,9 +310,7 @@ class GroupRequiredMixin(AccessMixin):
 
     def get_group_required(self):
         if self.group_required is None or (
-                not isinstance(self.group_required,
-                               (list, tuple) + six.string_types)
-        ):
+                not isinstance(self.group_required, (list, tuple, str))):
 
             raise ImproperlyConfigured(
                 '{0} requires the "group_required" attribute to be set and be '

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -5,7 +5,6 @@ from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.utils import six
 
 
 class JSONResponseMixin(object):
@@ -18,9 +17,7 @@ class JSONResponseMixin(object):
     json_encoder_class = DjangoJSONEncoder
 
     def get_content_type(self):
-        if (self.content_type is not None and
-            not isinstance(self.content_type,
-                           (six.string_types, six.text_type))):
+        if (self.content_type is not None and not isinstance(self.content_type, str)):
             raise ImproperlyConfigured(
                 '{0} is missing a content type. Define {0}.content_type, '
                 'or override {0}.get_content_type().'.format(

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.functional import curry, Promise
@@ -114,8 +113,7 @@ class FormValidMessageMixin(MessageMixin):
                 '{0}.get_form_valid_message().'.format(self.__class__.__name__)
             )
 
-        if not isinstance(self.form_valid_message,
-                          (six.string_types, six.text_type, Promise)):
+        if not isinstance(self.form_valid_message, (str, Promise)):
             raise ImproperlyConfigured(
                 '{0}.form_valid_message must be a str or unicode '
                 'object.'.format(self.__class__.__name__)
@@ -160,8 +158,7 @@ class FormInvalidMessageMixin(MessageMixin):
                 '{0}.get_form_invalid_message().'.format(
                     self.__class__.__name__))
 
-        if not isinstance(self.form_invalid_message,
-                          (six.string_types, six.text_type, Promise)):
+        if not isinstance(self.form_invalid_message, (str, Promise)):
             raise ImproperlyConfigured(
                 '{0}.form_invalid_message must be a str or unicode '
                 'object.'.format(self.__class__.__name__))

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -1,8 +1,9 @@
+from functools import partialmethod
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
-from django.utils.functional import curry, Promise
+from django.utils.functional import Promise
 from django.views.decorators.csrf import csrf_exempt
 try:
     from django.urls import reverse
@@ -72,7 +73,7 @@ class _MessageAPIWrapper(object):
     def __init__(self, request):
         for name in self.API:
             api_fn = getattr(messages.api, name)
-            setattr(self, name, curry(api_fn, request))
+            setattr(self, name, partialmethod(api_fn, request))
 
 
 class _MessageDescriptor(object):


### PR DESCRIPTION
Both django.utils.six and django.utils.functional.curry were removed in django 3.0.