### PR TITLE
Add compatibility for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,26 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 matrix:
     include:
-      - python: 2.7
-        env: TOX_ENV=py27-django111
-      - python: 3.4
-        env: TOX_ENV=py34-django111
-      - python: 3.4
-        env: TOX_ENV=py34-django20
       - python: 3.5
-        env: TOX_ENV=py35-django111
-      - python: 3.5
-        env: TOX_ENV=py35-django20
+        env: TOX_ENV=py35-django22
       - python: 3.6
-        env: TOX_ENV=py36-django111
+        env: TOX_ENV=py36-django22
+      - python: 3.7
+        env: TOX_ENV=py37-django22
+      - python: 3.8
+        env: TOX_ENV=py38-django22
       - python: 3.6
-        env: TOX_ENV=py36-django20
+        env: TOX_ENV=py36-django30
+      - python: 3.7
+        env: TOX_ENV=py37-django30
+      - python: 3.8
+        env: TOX_ENV=py38-django30
+      - python: 3.6
+        env: TOX_ENV=py36-django31
+      - python: 3.7
+        env: TOX_ENV=py37-django31
+      - python: 3.8
+        env: TOX_ENV=py38-django31
 
 script: tox -e $TOX_ENV
 

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -9,9 +9,18 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
                          Http404, HttpResponse, StreamingHttpResponse)
 from django.shortcuts import resolve_url
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.timezone import now
+
+try:
+    from django.utils import six
+except ImportError:
+    try:
+        import six
+    except ImportError:
+        raise ImproperlyConfigured(
+            'Starting from django 3.0, you must provide your own installation '
+            'of the `six` package.')
 
 
 class AccessMixin(object):

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -5,7 +5,16 @@ from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.utils import six
+
+try:
+    from django.utils import six
+except ImportError:
+    try:
+        import six
+    except ImportError:
+        raise ImproperlyConfigured(
+            'Starting from django 3.0, you must provide your own installation '
+            'of the `six` package.')
 
 
 class JSONResponseMixin(object):

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -1,14 +1,28 @@
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
-from django.utils.functional import curry, Promise
+from django.utils.functional import Promise
 from django.views.decorators.csrf import csrf_exempt
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
+
+try:
+    from django.utils import six
+except ImportError:
+    try:
+        import six
+    except ImportError:
+        raise ImproperlyConfigured(
+            'Starting from django 3.0, you must provide your own installation '
+            'of the `six` package.')
+
+try:
+    from django.utils.functional import curry
+except ImportError:
+    from functools import partialmethod as curry
 
 
 class CsrfExemptMixin(object):

--- a/braces/views/_forms.py
+++ b/braces/views/_forms.py
@@ -22,7 +22,7 @@ except ImportError:
 try:
     from django.utils.functional import curry
 except ImportError:
-    from functools import partialmethod as curry
+    from functools import partial as curry
 
 
 class CsrfExemptMixin(object):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.exceptions import ImproperlyConfigured
-from django.contrib.auth.views import login
+from django.contrib.auth.views import LoginView
 from . import views
 from .compat import include, url, patterns_compat
 
@@ -116,8 +116,8 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    url(r'^accounts/login/$', login, {'template_name': 'blank.html'}),
-    url(r'^auth/login/$', login, {'template_name': 'blank.html'}),
+    url(r'^accounts/login/$', LoginView.as_view(template_name='blank.html')),
+    url(r'^auth/login/$', LoginView.as_view(template_name='blank.html')),
 ]
 try:
     urlpatterns += [

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{27}-django{111},py{34,35,36}-django{111,20}
+envlist = py{35,36,37,38}-django{22},py{36,37,38}-django{30,31}
 install_command = pip install {opts} "{packages}"
 
 [testenv]
 basepython =
-    py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 
 commands =
 	{posargs:py.test}
@@ -15,10 +15,9 @@ commands =
 deps =
     mock
     factory_boy==2.8.1
-    py{27,34}: pytest==2.9.1
-    py{27,34}: pytest-django==2.9.1
-    py{35,36}: pytest-django>2.9.1
-    py{27,34,35,36}: coverage==4.1
+    py{35,36,37,38}: pytest-django>2.9.1
+    py{35,36,37,38}: coverage==4.1
     argparse
-    django111: Django>=1.11,<1.12
-    django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2


### PR DESCRIPTION
Fix issue #253 by adding django 3.0 support.

The only things that were broken are some import to functions that have been removed from the django codebase.

To the best of my knowledge, I also updated the Tox and Travis configuration to respect the ["Supported Django versions" part of the Readme](https://github.com/brack3t/django-braces#supported-django-versions).