### PR TITLE
add Mfon Eti-mfon to contributors

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -31,6 +31,7 @@ Direct Contributors
 * Mike Bryant
 * Fabio C. Barrionuevo da Luz
 * Sam Spencer
+* Mfon Eti-mfon
 
 Other Contributors
 ==================


### PR DESCRIPTION
This PR adds Mfon Eti-mfon (@mfonism) to the `CONTRIBUTORS.txt` file as per https://github.com/brack3t/django-braces/pull/254#issuecomment-567288232