### PR TITLE
Front-end example: ordering variable not defined

### DIFF
--- a/docs/other.rst
+++ b/docs/other.rst
@@ -431,11 +431,11 @@ If you're using bootstrap you could create a template like the following:
                 order_by_param,
                 ordering_param;
 
-            if (order_by === column_name) {
+            if (order_by_param === column_name) {
                 $el.addClass('current');
-                $el.addClass(ordering);
+                $el.addClass(ordering_param);
                 $el.append('<span class="caret"></span>');
-                if (ordering === 'asc') {
+                if (ordering_param === 'asc') {
                     $el.addClass('dropup');
                     next_order = 'desc';
                 }


### PR DESCRIPTION
Changed **ordering** to **ordering_param**, what I think It was the right variable to call, its working fine now. I am not a jQuery expert but this solved the problem for me.