### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/other.rst
+++ b/docs/other.rst
@@ -585,7 +585,7 @@ AllVerbsMixin
 
 .. versionadded:: 1.4
 
-This mixin allows you to specify a single method that will responsed to all HTTP verbs, making a class-based view behave much like a function-based view.
+This mixin allows you to specify a single method that will respond to all HTTP verbs, making a class-based view behave much like a function-based view.
 
 ::
 

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -660,7 +660,7 @@ class TestUserPassesTestMixin(_TestAccessBasicsMixin, test.TestCase):
     view_not_implemented_class = UserPassesTestNotImplementedView
     view_not_implemented_url = "/user_passes_test_not_implemented/"
 
-    # for testing with passing and not passsing func_test
+    # for testing with passing and not passing func_test
     def build_authorized_user(self, is_superuser=False):
         """Get a test-passing user"""
         return UserFactory(


### PR DESCRIPTION
There are small typos in:
- docs/other.rst
- tests/test_access_mixins.py

Fixes:
- Should read `respond` rather than `responsed`.
- Should read `passing` rather than `passsing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md